### PR TITLE
cache pagehits when spading items

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -537,7 +537,8 @@ export enum ItemType {
   Booze,
   Spleen,
   Offhand,
-  FamiliarEquip,
+  SpecificFamiliarEquip,
+  GenericFamiliarEquipment,
   Unknown,
 }
 
@@ -546,7 +547,8 @@ export const ITEM_SPADING_TYPES: Record<ItemType, string> = {
   [ItemType.Booze]: "Booze",
   [ItemType.Spleen]: "Spleen Item",
   [ItemType.Offhand]: "Offhand",
-  [ItemType.FamiliarEquip]: "Familiar Equipment",
+  [ItemType.SpecificFamiliarEquip]: "Familiar Equipment (Specific)",
+  [ItemType.GenericFamiliarEquipment]: "Familiar Equipment (Generic)",
   [ItemType.Unknown]: "",
 };
 
@@ -574,7 +576,7 @@ export const ITEM_SPADING_CALLS = [
       },
     ],
     visitMatch: /Only a specific familiar type \((?<addl>^\)*)\) can equip this item/,
-    type: ItemType.FamiliarEquip,
+    type: ItemType.SpecificFamiliarEquip,
     additionalData: true,
   },
   {
@@ -614,3 +616,8 @@ export const ITEM_SPADING_CALLS = [
     additionalData: false,
   },
 ];
+
+export enum SpadingFamiliars {
+  DEFAULT = 198,
+  GHOST = 282,
+}

--- a/src/kolclient.ts
+++ b/src/kolclient.ts
@@ -626,4 +626,23 @@ export class KOLClient {
       return { id: "", level: 0, class: "Unknown" };
     }
   }
+
+  async ensureFamiliar(familiarId: number): Promise<void> {
+    await this.tryRequestWithLogin("familiar.php", {
+      action: "newfam",
+      newfam: familiarId.toFixed(0),
+    });
+  }
+
+  async isGenericEquipment(itemId: number): Promise<boolean> {
+    return Boolean(
+      /Ghosts can't wear equipment/.exec(
+        await this.tryRequestWithLogin("inv_equip.php", {
+          action: "equip",
+          which: 2,
+          whichitem: itemId,
+        })
+      )
+    );
+  }
 }


### PR DESCRIPTION
one problem here is that right now we cache based on url only without paying attention to parameters. I think even once we have ghosts it'll be fine. Ghosts will annoyingly require familiar swapping, which, oh that's why I wanted to do it in that order. Alright I'll figure it out, everything is fine.