### PR TITLE
using the old syntax for db connections

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -2,5 +2,7 @@ import { Pool } from "pg";
 
 export const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
-  ssl: false,
+  ssl: {
+    rejectUnauthorized: false,
+  },
 });


### PR DESCRIPTION
going to put everything i just talked about in #lass-dev here.

this morning, we had a massive breaking oaf error where me and dictator trying to whitelist user Xyresic caused oaf to have a breaking crash that was not fixable through any reasonable means. it caused major client authentication errors and implied that the database had Problems :tm:. i did the following (useless, but good to note) tasks while trying to fix it:

- logged in to the database manually to find any issues. (no issues. every table is normal and there was zero evidence of data issues.)
- redeployed a handful of times, both from main and branches. at this point, every deploy was breaking with a huge pants-shitting fuckup on simply authenticating to the database, despite the fact that (as noted) i can manually log in to the database.
- logged in to jalen manually, and manually whitelisted the weird user that caused this huge crash (it worked fine, there were absolutely no issues. the user exists. i remain baffled by what the fuck happened.)
- confirmed that the environment config variables are proper matches (ie kol_user/kol_pass in the code)
- confirmed that the database URL i used to connect to the DB is the same one heroku is using in the environment config. it is the same.
- went through the code to try and identify any major issues. best i can see, the only area in /whitelist that looks fragile to me is getBasicDetailsForUser; that matcher (located [here](https://github.com/loathers/oaf/blob/eeb39740e98e379c2b2f7f0136cbca9367eec770/src/kol.ts#L538)) feels shaky and is probably where we are getting some element of the finicky-ness here.

i then decided to compare how Phill created the database client pool in the old code vs how it was done in the new code. i found one small syntax issue, and found a few stackoverflow issue/solutions that implied the old syntax was better than the new syntax (with "better" here meaning "does not cause authentication crashes"). so this PR literally just changes `ssl: false` to `ssl: { rejectUnauthorized: false }`. i deployed this branch and somehow it works. /whitelist works again, it logs in perfectly fine, etc. completely fucking baffling. no idea what the fuck is the issue. but it works so whatever i guess.

