### PR TITLE
initial stab at /player command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@prisma/client": "^4.10.1",
         "async-mutex": "^0.3.1",
         "axios": "^0.27.2",
+        "date-fns": "^2.29.3",
         "discord.js": "^14.7.1",
         "dotenv": "^16.0.1",
         "html-entities": "^2.3.2",
@@ -35,7 +36,7 @@
       },
       "engines": {
         "node": "^18.2.0",
-        "npm": "^9.0.0"
+        "npm": "^8.9.0 || ^9.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1215,6 +1216,18 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "node_modules/date-fns": {
+      "version": "2.29.3",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
+      "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==",
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -3293,6 +3306,11 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "date-fns": {
+      "version": "2.29.3",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
+      "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA=="
     },
     "debug": {
       "version": "4.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
       },
       "engines": {
         "node": "^18.2.0",
-        "npm": "^8.9.0"
+        "npm": "^9.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@prisma/client": "^4.10.1",
     "async-mutex": "^0.3.1",
     "axios": "^0.27.2",
+    "date-fns": "^2.29.3",
     "discord.js": "^14.7.1",
     "dotenv": "^16.0.1",
     "html-entities": "^2.3.2",
@@ -39,6 +40,6 @@
   },
   "engines": {
     "node": "^18.2.0",
-    "npm": "^8.9.0"
+    "npm": "^8.9.0 || ^9.0.0"
   }
 }

--- a/src/clients/kol.ts
+++ b/src/clients/kol.ts
@@ -56,7 +56,7 @@ type PartialPlayer = {
   class: string;
 };
 
-interface FullPlayer {
+interface FullPlayer extends PartialPlayer {
   ascensions: number;
   trophies: number;
   tattoos: number;
@@ -65,8 +65,6 @@ interface FullPlayer {
   lastLogin: string;
   hasDisplayCase: boolean;
 };
-
-interface FullPlayer extends PartialPlayer {};
 
 function sanitiseBlueText(blueText: string | undefined): string {
   if (!blueText) return "";
@@ -431,6 +429,7 @@ export class KoLClient {
       const profile = await this.tryRequestWithLogin("showplayer.php", { who: playerToLookup.id });
       const header = profile.match(/<b>([^>]*?)<\/b> \(#(\d+)\)<br>/);
       if (!header) return null;
+
       const ascensions = Number(profile.match(/>Ascensions<\/a>:<\/b><\/td><td>(.*?)<\/td>/)?.[1] ?? 0);
       const trophies = Number(profile.match(/>Trophies Collected:<\/b><\/td><td>(.*?)<\/td>/)?.[1] ?? 0);
       const tattoos = Number(profile.match(/>Tattoos Collected:<\/b><\/td><td>(.*?)<\/td>/)?.[1] ?? 0);
@@ -439,12 +438,8 @@ export class KoLClient {
       const lastLogin = profile.match(/>Last Login:<\/b><\/td><td>(.*?)<\/td>/)?.[1] ?? "a date between now and February 10th, 2003";
       const hasDisplayCase = profile.match(/Display Case<\/b><\/a> in the Museum<\/td>/) !== null;
 
-
       return {
-        id: playerToLookup.id,
-        name: playerToLookup.name,
-        level: playerToLookup.level,
-        class: playerToLookup.class,
+        ...playerToLookup,
         ascensions,
         trophies,
         tattoos,

--- a/src/clients/kol.ts
+++ b/src/clients/kol.ts
@@ -429,25 +429,24 @@ export class KoLClient {
       const profile = await this.tryRequestWithLogin("showplayer.php", { who: id });
       const header = profile.match(/<b>([^>]*?)<\/b> \(#(\d+)\)<br>/);
       if (!header) return null;
-
-      const ascensionCount = Number(profile.match(/>Ascensions<\/a>:<\/b><\/td><td>(.*?)<\/td>/)?.[1] ?? 0);
-      const trophyCount = Number(profile.match(/>Trophies Collected:<\/b><\/td><td>(.*?)<\/td>/)?.[1] ?? 0);
-      const tattooCount = Number(profile.match(/>Tattoos Collected:<\/b><\/td><td>(.*?)<\/td>/)?.[1] ?? 0);
-      const favFood = profile.match(/>Favorite Food:<\/b><\/td><td>(.*?)<\/td>/)?.[1] ?? "toast (probably)";
-      const favBooze = profile.match(/>Favorite Booze:<\/b><\/td><td>(.*?)<\/td>/)?.[1] ?? "cold butter (probably)";
+      const ascensions = Number(profile.match(/>Ascensions<\/a>:<\/b><\/td><td>(.*?)<\/td>/)?.[1] ?? 0);
+      const trophies = Number(profile.match(/>Trophies Collected:<\/b><\/td><td>(.*?)<\/td>/)?.[1] ?? 0);
+      const tattoos = Number(profile.match(/>Tattoos Collected:<\/b><\/td><td>(.*?)<\/td>/)?.[1] ?? 0);
+      const favoriteFood = profile.match(/>Favorite Food:<\/b><\/td><td>(.*?)<\/td>/)?.[1] ?? "toast (probably)";
+      const favoriteBooze = profile.match(/>Favorite Booze:<\/b><\/td><td>(.*?)<\/td>/)?.[1] ?? "cold butter (probably)";
       const lastLogin = profile.match(/>Last Login:<\/b><\/td><td>(.*?)<\/td>/)?.[1] ?? "a date between now and February 10th, 2003";
-      const displayCaseFound = profile.match(/Display Case<\/b><\/a> in the Museum<\/td>/) !== null;
+      const hasDisplayCase = profile.match(/Display Case<\/b><\/a> in the Museum<\/td>/) !== null;
 
 
       return {
-        ascensions: ascensionCount,
-        trophies: trophyCount,
-        tattoos: tattooCount,
-        favoriteFood: favFood,
-        favoriteBooze: favBooze,
-        lastLogin:lastLogin,
-        hasDisplayCase:displayCaseFound,
-      };
+        ascensions,
+        trophies,
+        tattoos,
+        favoriteFood,
+        favoriteBooze,
+        lastLogin,
+        hasDisplayCase
+      };       
     } catch {
       return null;
     }

--- a/src/clients/kol.ts
+++ b/src/clients/kol.ts
@@ -56,7 +56,7 @@ type PartialPlayer = {
   class: string;
 };
 
-type FullPlayer = {
+interface FullPlayer {
   ascensions: number;
   trophies: number;
   tattoos: number;
@@ -65,6 +65,8 @@ type FullPlayer = {
   lastLogin: string;
   hasDisplayCase: boolean;
 };
+
+interface FullPlayer extends PartialPlayer {};
 
 function sanitiseBlueText(blueText: string | undefined): string {
   if (!blueText) return "";
@@ -424,9 +426,9 @@ export class KoLClient {
     return match?.[1] ?? null;
   }
 
-  async getPlayerInformation(id: number): Promise<FullPlayer | null> {
+  async getPlayerInformation(playerToLookup: PartialPlayer): Promise<FullPlayer | null> {
     try {
-      const profile = await this.tryRequestWithLogin("showplayer.php", { who: id });
+      const profile = await this.tryRequestWithLogin("showplayer.php", { who: playerToLookup.id });
       const header = profile.match(/<b>([^>]*?)<\/b> \(#(\d+)\)<br>/);
       if (!header) return null;
       const ascensions = Number(profile.match(/>Ascensions<\/a>:<\/b><\/td><td>(.*?)<\/td>/)?.[1] ?? 0);
@@ -439,6 +441,10 @@ export class KoLClient {
 
 
       return {
+        id: playerToLookup.id,
+        name: playerToLookup.name,
+        level: playerToLookup.level,
+        class: playerToLookup.class,
         ascensions,
         trophies,
         tattoos,

--- a/src/clients/kol.ts
+++ b/src/clients/kol.ts
@@ -63,6 +63,7 @@ type FullPlayer = {
   favoriteFood: string;
   favoriteBooze: string;
   lastLogin: string;
+  hasDisplayCase: boolean;
 };
 
 function sanitiseBlueText(blueText: string | undefined): string {
@@ -435,6 +436,7 @@ export class KoLClient {
       const favFood = profile.match(/>Favorite Food:<\/b><\/td><td>(.*?)<\/td>/)?.[1] ?? "toast (probably)";
       const favBooze = profile.match(/>Favorite Booze:<\/b><\/td><td>(.*?)<\/td>/)?.[1] ?? "cold butter (probably)";
       const lastLogin = profile.match(/>Last Login:<\/b><\/td><td>(.*?)<\/td>/)?.[1] ?? "a date between now and February 10th, 2003";
+      const displayCaseFound = profile.match(/Display Case<\/b><\/a> in the Museum<\/td>/) !== null;
 
 
       return {
@@ -443,7 +445,8 @@ export class KoLClient {
         tattoos: tattooCount,
         favoriteFood: favFood,
         favoriteBooze: favBooze,
-        lastLogin:lastLogin
+        lastLogin:lastLogin,
+        hasDisplayCase:displayCaseFound,
       };
     } catch {
       return null;

--- a/src/clients/snapshot.ts
+++ b/src/clients/snapshot.ts
@@ -1,0 +1,22 @@
+import axios from "axios";
+import { parse } from "date-fns";
+
+export class SnapshotClient {
+  constructor() {}
+
+  static toLink(input: string) {
+    return `https://api.aventuristo.net/av-snapshot?u=${encodeURI(input.replace(/\s/g, "%20"))}`;
+  }
+
+  async getInfo(playerName: string) {
+    const link = SnapshotClient.toLink(playerName);
+    const { data, status } = await axios.get<string>(link);
+    if (status !== 200 || !data) return null;
+    const dateString = data.match(/taken (\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) UTC/)?.[1];
+    if (!dateString) return null;
+    const date = parse(dateString, "yyyy-MM-dd HH:mm:ss", new Date());
+    return { date, link };
+  }
+}
+
+export const snapshotClient = new SnapshotClient();

--- a/src/commands/clan/brainiac.ts
+++ b/src/commands/clan/brainiac.ts
@@ -1,7 +1,7 @@
 import { ChatInputCommandInteraction, SlashCommandBuilder } from "discord.js";
 
-import { clanState } from "./_clans";
 import { prisma } from "../../clients/database";
+import { clanState } from "./_clans";
 
 export const data = new SlashCommandBuilder()
   .setName("brainiac")

--- a/src/commands/kol/player.ts
+++ b/src/commands/kol/player.ts
@@ -15,7 +15,7 @@ export const data = new SlashCommandBuilder()
   .addStringOption((o) =>
     o
       .setName("player")
-      .setDescription("The KOL username of the player you're looking up.")
+      .setDescription("The KOL username or ID of the player you're looking up.")
       .setRequired(true)
     );
 
@@ -37,15 +37,15 @@ export async function execute(interaction: ChatInputCommandInteraction) {
     const player = await kolClient.getPartialPlayer(playerNameOrId);
 
     if (!player) {
-        interaction.editReply({content:"According to KOL, this player does not exist."});
+        interaction.editReply({content: `According to KOL, player ${playerNameOrId} does not exist.`});        
         return;
     }
 
     const playerInfo = await kolClient.getPlayerInformation(player.id);
 
     if (!playerInfo) {
-        interaction.editReply({content:"While this player exists, this command didn't work. Weird."});
-        return;
+        interaction.editReply({content: `While player ${playerNameOrId} exists, this command didn't work. Weird.`});
+        return;    
     }
 
     const displayCaseLine = playerInfo.hasDisplayCase ? `Check out this player's display case at ${bold(hyperlink("their museum page!", toMuseumLink(String(player.id))))}` : "";

--- a/src/commands/kol/player.ts
+++ b/src/commands/kol/player.ts
@@ -1,0 +1,84 @@
+import {
+    ChatInputCommandInteraction,
+    SlashCommandBuilder,
+    bold, 
+    hyperlink
+  } from "discord.js";
+  
+import { kolClient } from "../../clients/kol";
+import { pluralize, toKoldbLink, toSnapshotLink } from "../../utils";
+
+
+export const data = new SlashCommandBuilder()
+  .setName("player")
+  .setDescription("Look up information on a given player.")
+  .addStringOption((o) =>
+    o
+      .setName("player")
+      .setDescription("The KOL username of the player you're looking up.")
+      .setRequired(true)
+    );
+
+export async function execute(interaction: ChatInputCommandInteraction) {
+    const member = interaction.member;
+  
+    if (!member) {
+      interaction.reply({
+        content: "You have to perform this action from within a Guild.",
+        ephemeral: true,
+      });
+      return;
+    }
+
+    const playerNameOrId = interaction.options.getString("player", true);
+
+    await interaction.deferReply();
+
+    const player = await kolClient.getPartialPlayer(playerNameOrId);
+
+    if (!player) {
+        interaction.editReply({content:"According to KOL, this player does not exist."});
+        return;
+    }
+
+    const playerInfo = await kolClient.getPlayerInformation(player.id);
+
+    if (!playerInfo) {
+        interaction.editReply({content:"While this player exists, this command didn't work. Weird."});
+        return;
+    }
+
+    const playerInfoFormatted = [
+        `This user is currently a ${bold(player.class)} at level ${player.level}`,
+        `They have completed ${bold(
+            hyperlink(
+                    `${playerInfo.ascensions}`,
+                    toKoldbLink(player.name)))} 
+            ${pluralize(playerInfo.ascensions,"ascension","ascensions")}.`,
+        `Loves eating ${playerInfo.favoriteFood}.`,
+        `Loves drinking ${playerInfo.favoriteBooze}.`,
+        ``,
+        `If it exists, their av-snapshot is located ${hyperlink(
+            "here", toSnapshotLink(player.name))}`,
+        ``,
+        `${player.name} last logged in on ${playerInfo.lastLogin}`
+
+    ]
+
+    try {
+        await interaction.editReply({
+            content: null,
+            embeds: [
+                {
+                    title: `${bold(player.name)} (#${player.id})`,
+                    description: playerInfoFormatted.join("\n"),
+                },
+            ],
+        });
+    } catch {
+        await interaction.editReply(
+            "I was unable to fetch this user, sorry. I might be unable to log in!"
+        );
+    }
+
+}

--- a/src/commands/kol/player.ts
+++ b/src/commands/kol/player.ts
@@ -6,7 +6,7 @@ import {
   } from "discord.js";
   
 import { kolClient } from "../../clients/kol";
-import { pluralize, toKoldbLink, toSnapshotLink } from "../../utils";
+import { pluralize, toKoldbLink, toMuseumLink, toSnapshotLink } from "../../utils";
 
 
 export const data = new SlashCommandBuilder()
@@ -48,6 +48,8 @@ export async function execute(interaction: ChatInputCommandInteraction) {
         return;
     }
 
+    const displayCaseLine = playerInfo.hasDisplayCase ? `Check out this player's display case at ${bold(hyperlink("their museum page!", toMuseumLink(String(player.id))))}` : "";
+
     const playerInfoFormatted = [
         `This user is currently a ${bold(player.class)} at level ${player.level}`,
         `They have completed ${bold(
@@ -55,6 +57,7 @@ export async function execute(interaction: ChatInputCommandInteraction) {
                     `${playerInfo.ascensions}`,
                     toKoldbLink(player.name)))} 
             ${pluralize(playerInfo.ascensions,"ascension","ascensions")}.`,
+        displayCaseLine,
         `Loves eating ${playerInfo.favoriteFood}.`,
         `Loves drinking ${playerInfo.favoriteBooze}.`,
         ``,

--- a/src/commands/kol/whois.ts
+++ b/src/commands/kol/whois.ts
@@ -14,12 +14,12 @@ import { snapshotClient } from "../../clients/snapshot";
 import { toKoldbLink, toMuseumLink } from "../../utils";
 
 export const data = new SlashCommandBuilder()
-  .setName("player")
+  .setName("whois")
   .setDescription("Look up information on a given player.")
   .addStringOption((option) =>
     option
       .setName("player")
-      .setDescription("The KOL username or ID of the player you're looking up.")
+      .setDescription("The name or id of the KoL player you're looking up.")
       .setRequired(true)
   );
 
@@ -78,10 +78,6 @@ export async function execute(interaction: ChatInputCommandInteraction) {
   const playerEmbed = createEmbed()
     .setTitle(`${bold(partialPlayer.name)} (#${partialPlayer.id})`)
     .setThumbnail(player.avatar)
-    .setAuthor({
-      name: "OAF Player Summary",
-      iconURL: "http://images.kingdomofloathing.com/itemimages/oaf.gif",
-    })
     .addFields(fields);
 
   try {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,11 +19,7 @@ export function toWikiLink(input: string): string {
 }
 
 export function toKoldbLink(input: string): string {
-  return `koldb.com/player.php?name=${encodeURI(input.replace(/\s/g, "%20"))}`;
-}
-
-export function toSnapshotLink(input: string): string {
-  return `https://api.aventuristo.net/av-snapshot?u=${encodeURI(input.replace(/\s/g, "%20"))}`;
+  return `https://koldb.com/player.php?name=${encodeURI(input.replace(/\s/g, "%20"))}`;
 }
 
 export function toMuseumLink(input: string): string {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,6 +26,10 @@ export function toSnapshotLink(input: string): string {
   return `https://api.aventuristo.net/av-snapshot?u=${encodeURI(input.replace(/\s/g, "%20"))}`;
 }
 
+export function toMuseumLink(input: string): string {
+  return `https://museum.loathers.net/player/${encodeURI(input.replace(/\s/g, ""))}`;
+}
+
 export function parseNumber(input?: string): number {
   return parseInt(input?.replace(",", "") || "0");
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,6 +18,14 @@ export function toWikiLink(input: string): string {
     .replace(/\)/g, "%29")}`;
 }
 
+export function toKoldbLink(input: string): string {
+  return `koldb.com/player.php?name=${encodeURI(input.replace(/\s/g, "%20"))}`;
+}
+
+export function toSnapshotLink(input: string): string {
+  return `https://api.aventuristo.net/av-snapshot?u=${encodeURI(input.replace(/\s/g, "%20"))}`;
+}
+
 export function parseNumber(input?: string): number {
   return parseInt(input?.replace(",", "") || "0");
 }


### PR DESCRIPTION
wanted to try my hand at a new command i've wanted for a while. general idea is that it will generate a small brick with information from a user's profile. it will ingest either ID or player name then spit out the following:

- player name + id
- player's class & level
- link to the player's koldb page & number of ascensions
- favorite food/booze (we don't really need this i just thought it was funny)
- a link to av-snapshot (which we can swap out with greenbox when greenbox has links :-D )
- the player's last login date

a few general thoughts i have not covered yet:

- could have it create a small medals badge type thing with a user's commendations
- could have it include the user's "current" turncount as of the moment it checked
- could have it return path + class instead of just class
- could add some kind of image to the output though idk what it would be tbh
- once we have oauf we could have it include the user's discord handle

i have not actually tested this live yet, it might be good to test in the private server first but vscode validated all the code and i think it is reasonably straightforward as to what it is doing. i think it is currently living in the right place in /kol/ but obviously let me know if i have made a mess of the org structure in any way. organizationally there is probably a case to integrating it into getPartialPlayerFromId, but i thought making it a separate "get full player" func in KoLClient made more sense to me intuitively.

let me know whatcha think samwise gamausie