### PR TITLE
Make the `tagger` replies always ephemeral

### DIFF
--- a/src/commands/misc/tagger.ts
+++ b/src/commands/misc/tagger.ts
@@ -126,7 +126,7 @@ async function handleModal(targetMessage: Message<true>, interaction: ModalSubmi
       return;
     }
 
-    await interaction.deferReply();
+    await interaction.deferReply({ ephemeral: true});
 
     await prisma.tag.delete({ where: { tag: existing.tag } });
     await interaction.editReply(

--- a/src/commands/misc/tagger.ts
+++ b/src/commands/misc/tagger.ts
@@ -112,9 +112,6 @@ async function handleModal(targetMessage: Message<true>, interaction: ModalSubmi
 
   const tagNameInUse = await prisma.tag.findUnique({ where: { tag } });
 
-  // We shouldn't do async things without first marking the reply as deferred. However, we want to reply ephemerally
-  // on failure and publicly on success. So here we are deferring reply to a little later than normal.
-
   const existing = await getExistingTagForMessage(targetMessage);
 
   // A special tag name can be used to delete existing tags


### PR DESCRIPTION
This will make the `tag` feature less disruptive and possibly even less memed, which would be nice; the particular goal here is for the #useful-resources channel, so worst case scenario is I could have ephemerality be determined by channel instead of always being `true`. But I think there's not really a compelling reason to want the `tagger` feature to leave a public paper trail.