### PR TITLE
More specific thing query fixes

### DIFF
--- a/src/clients/wiki.ts
+++ b/src/clients/wiki.ts
@@ -507,6 +507,25 @@ export class WikiClient {
     console.log("Google search stumped, I give up");
     return undefined;
   }
+
+  async getWikiLink(thing: Thing) {
+    const type = thing.constructor.name;
+    const block = Math.floor(thing.id / 100) * 100;
+    const url = `https://kol.coldfront.net/thekolwiki/index.php/${type}s_by_number_(${block}-${
+      block + 99
+    })`;
+
+    try {
+      const blockPage = await axios.get<string>(url);
+
+      const match = blockPage.data.match(new RegExp(`${thing.id}\\. <a href="([^"]+)"`));
+      if (!match) return null;
+
+      return `https://kol.coldfront.net${match[1]}`;
+    } catch (e) {
+      return null;
+    }
+  }
 }
 
 function nameFromWikiPage(url: string, data: string): string {

--- a/src/commands/wiki/item.ts
+++ b/src/commands/wiki/item.ts
@@ -34,7 +34,7 @@ export async function execute(interaction: ChatInputCommandInteraction) {
     return;
   }
 
-  embed.setTitle(item.name).setURL(await item.getWikiLink());
+  embed.setTitle(item.name).setURL(await wikiClient.getWikiLink(item));
 
   await item.addToEmbed(embed);
 

--- a/src/commands/wiki/item.ts
+++ b/src/commands/wiki/item.ts
@@ -1,10 +1,10 @@
 import {
   AutocompleteInteraction,
   ChatInputCommandInteraction,
-  EmbedBuilder,
   SlashCommandBuilder,
 } from "discord.js";
 
+import { createEmbed } from "../../clients/discord";
 import { wikiClient } from "../../clients/wiki";
 
 export const data = new SlashCommandBuilder()
@@ -24,7 +24,7 @@ export async function execute(interaction: ChatInputCommandInteraction) {
 
   const item = wikiClient.items.find((i) => i.id === itemId);
 
-  const embed = new EmbedBuilder();
+  const embed = createEmbed();
 
   if (!item) {
     await interaction.editReply({
@@ -33,6 +33,8 @@ export async function execute(interaction: ChatInputCommandInteraction) {
     });
     return;
   }
+
+  embed.setTitle(item.name).setURL(await item.getWikiLink());
 
   await item.addToEmbed(embed);
 

--- a/src/commands/wiki/monster.ts
+++ b/src/commands/wiki/monster.ts
@@ -1,10 +1,10 @@
 import {
   AutocompleteInteraction,
   ChatInputCommandInteraction,
-  EmbedBuilder,
   SlashCommandBuilder,
 } from "discord.js";
 
+import { createEmbed } from "../../clients/discord";
 import { wikiClient } from "../../clients/wiki";
 
 export const data = new SlashCommandBuilder()
@@ -24,7 +24,7 @@ export async function execute(interaction: ChatInputCommandInteraction) {
 
   const monster = wikiClient.monsters.find((i) => i.id === monsterId);
 
-  const embed = new EmbedBuilder();
+  const embed = createEmbed();
 
   if (!monster) {
     await interaction.editReply({
@@ -34,6 +34,7 @@ export async function execute(interaction: ChatInputCommandInteraction) {
     return;
   }
 
+  embed.setTitle(monster.name).setURL(await monster.getWikiLink());
   await monster.addToEmbed(embed);
 
   await interaction.editReply({

--- a/src/commands/wiki/monster.ts
+++ b/src/commands/wiki/monster.ts
@@ -34,7 +34,7 @@ export async function execute(interaction: ChatInputCommandInteraction) {
     return;
   }
 
-  embed.setTitle(monster.name).setURL(await monster.getWikiLink());
+  embed.setTitle(monster.name).setURL(await wikiClient.getWikiLink(monster));
   await monster.addToEmbed(embed);
 
   await interaction.editReply({

--- a/src/things/Monster.ts
+++ b/src/things/Monster.ts
@@ -67,6 +67,10 @@ export class Monster extends Thing {
     this.drops = drops;
   }
 
+  getImagePath() {
+    return `/adventureimages/${this.imageUrl}`;
+  }
+
   private getDropsDescription() {
     const meatMatcher = this.parameters.match(/Meat: (?<meat>[\d]+)/);
 

--- a/src/things/Thing.ts
+++ b/src/things/Thing.ts
@@ -1,5 +1,7 @@
 import { EmbedBuilder } from "discord.js";
 
+import { wikiClient } from "../clients/wiki";
+
 export class Thing {
   readonly id: number;
   readonly name: string;
@@ -11,12 +13,20 @@ export class Thing {
     this.imageUrl = imageUrl;
   }
 
+  async getWikiLink() {
+    return wikiClient.getWikiLink(this);
+  }
+
   async getDescription(): Promise<string> {
     throw "Implement me";
   }
 
+  getImagePath() {
+    return `/itemimages/${this.imageUrl}`;
+  }
+
   async addToEmbed(embed: EmbedBuilder): Promise<void> {
-    embed.setThumbnail(`http://images.kingdomofloathing.com/itemimages/${this.imageUrl}`);
+    embed.setThumbnail(`http://images.kingdomofloathing.com${this.getImagePath()}`);
     embed.setDescription(await this.getDescription());
   }
 }

--- a/src/things/Thing.ts
+++ b/src/things/Thing.ts
@@ -1,7 +1,5 @@
 import { EmbedBuilder } from "discord.js";
 
-import { wikiClient } from "../clients/wiki";
-
 export class Thing {
   readonly id: number;
   readonly name: string;
@@ -11,10 +9,6 @@ export class Thing {
     this.id = id;
     this.name = name;
     this.imageUrl = imageUrl;
-  }
-
-  async getWikiLink() {
-    return wikiClient.getWikiLink(this);
   }
 
   async getDescription(): Promise<string> {


### PR DESCRIPTION
- Filter out bad lines from mafia data
- Fix up some memoizing to clear caches when appropriate
- Add new /item and /monster query commands, rename /item to /itemdrop
- Improve specific thing queries, add code to find wiki links for Things with ids
