### PR TITLE
Stabilise reminders

### DIFF
--- a/prisma/migrations/20230903184039_reminders_in_db/migration.sql
+++ b/prisma/migrations/20230903184039_reminders_in_db/migration.sql
@@ -1,0 +1,15 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `reminderTime` on the `Reminder` table. All the data in the column will be lost.
+  - Added the required column `reminderDate` to the `Reminder` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Reminder" DROP COLUMN "reminderTime",
+ADD COLUMN     "reminderDate" TIMESTAMP(3) NOT NULL,
+ADD COLUMN     "reminderSent" BOOLEAN NOT NULL DEFAULT false;
+
+-- Change Settings table name
+ALTER TABLE "Settings" RENAME CONSTRAINT "Settings_pkey" TO "Setting_pkey";
+ALTER TABLE "Settings" RENAME TO "Setting";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,8 +25,9 @@ model Reminder {
   channelId          String
   userId             String
   messageContents    String
-  reminderTime       BigInt
+  reminderDate       DateTime
   interactionReplyId String?
+  reminderSent       Boolean @default(false)
 }
 
 model Raid {
@@ -46,7 +47,7 @@ model Tag {
   @@unique([guildId, channelId, messageId])
 }
 
-model Settings {
+model Setting {
   key String  @id
   value Json
 }


### PR DESCRIPTION
This rationalizes reminders somewhat. It now shouldn't be possible to lose a reminder without knowing why ever - and if someone notices that their reminder didn't come through, we have 30 days to diagnose the issue.

Also takes the opportunity to rename the Settings table to Setting, in line with the rest of the singular case table names.