### PR TITLE
Make greenbox historical api return total as number instead of object

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -90,7 +90,7 @@ app
     return res.status(StatusCodes.OK).json({
       data: greenbox.data,
       createdAt: greenbox.createdAt,
-      total: player._count,
+      total: player._count.greenbox,
     });
   })
   .get("/webhooks/subsrolling", async (req, res) => {


### PR DESCRIPTION
This way it will be consistent with the non-historical api

Pretty straightforward fix.