### PR TITLE
add wiki link to offers

### DIFF
--- a/src/commands/kol/offers.ts
+++ b/src/commands/kol/offers.ts
@@ -92,6 +92,7 @@ async function viewStandingOffers(interaction: ChatInputCommandInteraction) {
 
   const embed = createEmbed()
     .setTitle(`Standing Offers for ${item.name}`)
+    .setURL(await wikiClient.getWikiLink(item))
     .setDescription(offers.join("\n"))
     .setThumbnail(resolveKoLImage(item.getImagePath()));
 


### PR DESCRIPTION
Is it this simple? Based on item.ts, this looks like all that would be needed. I am sorely lacking in TS experience, and even less so with the discord bot architecture.