### PR TITLE
store raid logs in detail

### DIFF
--- a/packages/kol.js/src/Player.ts
+++ b/packages/kol.js/src/Player.ts
@@ -66,11 +66,11 @@ export class Player<IsFull extends boolean = boolean> {
     id: number,
   ): Promise<string | null> {
     try {
-      const profile = await client.fetchText("showplayer.php", {
-        searchParams: { who: id },
+      const profile = await client.fetchText("submitnewchat.php", {
+        searchParams: { graf: `/whois ${id}` },
       });
-      const name = profile.match(/<b>([^>]*?)<\/b> \(#(\d+)\)<br>/)?.[1];
-      return name || null;
+      const name = profile.match(/<a.*?><b.*?>(.*?) \(#(\d+)\)<\/b><\/a>/)?.[1];
+      return name ?? null;
     } catch {
       return null;
     }

--- a/packages/kol.js/src/Player.ts
+++ b/packages/kol.js/src/Player.ts
@@ -82,7 +82,7 @@ export class Player<IsFull extends boolean = boolean> {
   ): Promise<Player<false> | null> {
     try {
       const matcher =
-        /<tr><td class=small><b><a target=mainpane href="showplayer\.php\?who=(?<playerId>\d+)">(?<playerName>[^<]+)<\/a><\/b>.*?<\/td><td valign=top class=small>\d*<\/td><td valign=top class=small>(?:<img src=".*?">|(?<level>\d+))<\/td><td class=small valign=top>(?<class>[^<]+)<\/td><\/tr>/i;
+        /<tr><td class=small><b><a target=mainpane href="showplayer\.php\?who=(?<playerId>\d+)">(?<playerName>[^<]+)<\/a><\/b>.*?<\/td><td valign=top class=small>\d*<\/td><td valign=top class=small>(?:<img src=".*?">|(?<level>\d+))<\/td><td class=small valign=top>(?<class>[^<]*)<\/td><\/tr>/i;
       const search = await client.fetchText("searchplayer.php", {
         searchParams: {
           searchstring: name.replace(/_/g, "\\_"),

--- a/packages/oaf/prisma/migrations/20240917115819_raid_participation_table/migration.sql
+++ b/packages/oaf/prisma/migrations/20240917115819_raid_participation_table/migration.sql
@@ -1,0 +1,34 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `kills` on the `Player` table. All the data in the column will be lost.
+  - You are about to drop the column `skills` on the `Player` table. All the data in the column will be lost.
+  - Added the required column `clanId` to the `Raid` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- Custom: Truncate Raid table since we need to rescan
+TRUNCATE TABLE "Raid" CASCADE;
+
+-- AlterTable
+ALTER TABLE "Player" DROP COLUMN "kills",
+DROP COLUMN "skills";
+
+-- AlterTable
+ALTER TABLE "Raid" ADD COLUMN     "clanId" INTEGER NOT NULL;
+
+-- CreateTable
+CREATE TABLE "RaidParticipation" (
+    "raidId" INTEGER NOT NULL,
+    "playerId" INTEGER NOT NULL,
+    "skills" INTEGER NOT NULL,
+    "kills" INTEGER NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RaidParticipation_raidId_playerId_key" ON "RaidParticipation"("raidId", "playerId");
+
+-- AddForeignKey
+ALTER TABLE "RaidParticipation" ADD CONSTRAINT "RaidParticipation_raidId_fkey" FOREIGN KEY ("raidId") REFERENCES "Raid"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RaidParticipation" ADD CONSTRAINT "RaidParticipation_playerId_fkey" FOREIGN KEY ("playerId") REFERENCES "Player"("playerId") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/oaf/prisma/schema.prisma
+++ b/packages/oaf/prisma/schema.prisma
@@ -16,31 +16,29 @@ model Greenbox {
 }
 
 model Player {
-  playerId            Int             @id
+  playerId            Int                 @id
   playerName          String
   accountCreationDate DateTime?
-  kills               Int             @default(0)
-  skills              Int             @default(0)
-  doneWithSkills      Boolean         @default(false)
-  brainiac            Boolean         @default(false)
+  doneWithSkills      Boolean             @default(false)
+  brainiac            Boolean             @default(false)
   discordId           String?
   greenbox            Greenbox[]
   greenboxString      String?
   greenboxLastUpdate  DateTime?
-  thiccEntered        Boolean         @default(false)
-  thiccGifteeId       Int?            @unique
-  thiccGiftee         Player?         @relation("ThiccGiftee", fields: [thiccGifteeId], references: [playerId])
-  thiccGifter         Player?         @relation("ThiccGiftee")
+  thiccEntered        Boolean             @default(false)
+  thiccGifteeId       Int?                @unique
+  thiccGiftee         Player?             @relation("ThiccGiftee", fields: [thiccGifteeId], references: [playerId])
+  thiccGifter         Player?             @relation("ThiccGiftee")
   standingOffers      StandingOffer[]
+  raidParticipation   RaidParticipation[]
 }
 
 model StandingOffer {
-  itemId   Int
-  price    BigInt
-  buyerId  Int
+  itemId    Int
+  price     BigInt
+  buyerId   Int
   offeredAt DateTime @default(now())
-  buyer    Player @relation(fields: [buyerId], references: [playerId])
-
+  buyer     Player   @relation(fields: [buyerId], references: [playerId])
 
   @@unique([buyerId, itemId])
 }
@@ -57,7 +55,20 @@ model Reminder {
 }
 
 model Raid {
-  id Int @id
+  id            Int                 @id
+  clanId        Int
+  participation RaidParticipation[]
+}
+
+model RaidParticipation {
+  raidId   Int
+  raid     Raid   @relation(fields: [raidId], references: [id])
+  playerId Int
+  player   Player @relation(fields: [playerId], references: [playerId])
+  skills   Int
+  kills    Int
+
+  @@unique([raidId, playerId])
 }
 
 model Tag {

--- a/packages/oaf/src/commands/clan/brains.ts
+++ b/packages/oaf/src/commands/clan/brains.ts
@@ -53,7 +53,12 @@ export async function execute(interaction: ChatInputCommandInteraction) {
   );
 
   const players = await prisma.player.findMany({
-    where: { OR: [{ brainiac: true }, { skills: { gt: 0 } }] },
+    where: {
+      OR: [
+        { brainiac: true },
+        { raidParticipation: { some: { skills: { gt: 0 } } } },
+      ],
+    },
   });
 
   const playerNameUpdates: PrismaPromise<Player>[] = [];

--- a/packages/oaf/src/commands/clan/skills.test.ts
+++ b/packages/oaf/src/commands/clan/skills.test.ts
@@ -1,13 +1,20 @@
 import { beforeAll, expect, test } from "vitest";
 
 import { loadFixture } from "../../testUtils.js";
-import { Participation, getParticipationFromRaidLog } from "./skills.js";
+import {
+  Participation,
+  getParticipationFromRaidLog,
+  mergeParticipation,
+} from "./skills.js";
 
-let participation: Participation = new Map();
+let participation: Participation = {};
 
 beforeAll(async () => {
-  participation = getParticipationFromRaidLog(
-    await loadFixture(__dirname, "raidlog.html"),
+  participation = mergeParticipation(
+    {},
+    ...getParticipationFromRaidLog(
+      await loadFixture(__dirname, "raidlog.html"),
+    ),
   );
 });
 
@@ -15,20 +22,20 @@ const LAGGYCAT = 3137318;
 const SWAGGERFORTUNE = 3268818;
 
 test("Can parse raid log skills", () => {
-  expect(participation.get(LAGGYCAT)).toHaveProperty("skills", 1);
+  expect(participation[LAGGYCAT]).toHaveProperty("skills", 1);
 
-  const otherParticipantsSkills = [...participation.entries()]
-    .filter(([pid]) => pid !== LAGGYCAT)
-    .reduce((sum, [, { skills }]) => sum + skills, 0);
+  const otherParticipantsSkills = Object.values(participation)
+    .filter(({ playerId }) => playerId !== LAGGYCAT)
+    .reduce((sum, { skills }) => sum + skills, 0);
 
   expect(otherParticipantsSkills).toEqual(0);
 });
 
 test("Can parse raid log kills", () => {
-  expect(participation.get(SWAGGERFORTUNE)).toHaveProperty("kills", 346);
-  expect(participation.get(LAGGYCAT)).toHaveProperty("kills", 0);
+  expect(participation[SWAGGERFORTUNE]).toHaveProperty("kills", 346);
+  expect(participation[LAGGYCAT]).toHaveProperty("kills", 0);
 
-  const totalKills = [...participation.values()].reduce(
+  const totalKills = Object.values(participation).reduce(
     (sum, { kills }) => sum + kills,
     0,
   );


### PR DESCRIPTION
- **Store raid logs in their own table**
- **Use POJOs instead of Maps for participation**

This simplifies the code and adds a level of introspectability and verifiability to the numbers if necessary
