### PR TITLE
Use samsara instead of koldb for /whois ascension hyperlinks

### DIFF
--- a/packages/oaf/src/commands/kol/whois.ts
+++ b/packages/oaf/src/commands/kol/whois.ts
@@ -58,7 +58,7 @@ export async function execute(interaction: ChatInputCommandInteraction) {
       name: "Ascensions",
       value: player.ascensions > 0 ? hyperlink(
         player.ascensions.toLocaleString(),
-        toSamsaraLink(player.id) : 0,
+        toSamsaraLink(player.id)) : 0,
       ),
     });
 

--- a/packages/oaf/src/commands/kol/whois.ts
+++ b/packages/oaf/src/commands/kol/whois.ts
@@ -58,8 +58,7 @@ export async function execute(interaction: ChatInputCommandInteraction) {
       name: "Ascensions",
       value: player.ascensions > 0 ? hyperlink(
         player.ascensions.toLocaleString(),
-        toSamsaraLink(player.id)) : 0,
-      ),
+        toSamsaraLink(player.id)) : "0",
     });
 
     if (player.favoriteFood)

--- a/packages/oaf/src/commands/kol/whois.ts
+++ b/packages/oaf/src/commands/kol/whois.ts
@@ -13,7 +13,7 @@ import { prisma } from "../../clients/database.js";
 import { createEmbed, discordClient } from "../../clients/discord.js";
 import { snapshotClient } from "../../clients/snapshot.js";
 import { renderSvg } from "../../svgConverter.js";
-import { formatPlayer, toKoldbLink, toMuseumLink } from "../../utils.js";
+import { formatPlayer, toSamsaraLink, toMuseumLink } from "../../utils.js";
 import { findPlayer, identifyPlayer } from "../_player.js";
 
 export const data = new SlashCommandBuilder()
@@ -56,9 +56,9 @@ export async function execute(interaction: ChatInputCommandInteraction) {
   if (!astralSpirit) {
     fields.push({
       name: "Ascensions",
-      value: hyperlink(
+      value: player.ascensions > 0 ? hyperlink(
         player.ascensions.toLocaleString(),
-        toKoldbLink(player.name),
+        toSamsaraLink(player.id) : 0,
       ),
     });
 

--- a/packages/oaf/src/utils.ts
+++ b/packages/oaf/src/utils.ts
@@ -31,7 +31,6 @@ export function toWikiLink(input: string): string {
 }
 
 export function toSamsaraLink(id: number): string {
-  // NOTE: KOLDB does not support https. If this ever changes, this should change too.
   return `https://samsara.loathers.net/player/${id}`;
 }
 

--- a/packages/oaf/src/utils.ts
+++ b/packages/oaf/src/utils.ts
@@ -30,9 +30,9 @@ export function toWikiLink(input: string): string {
     .replace(/\)/g, "%29")}`;
 }
 
-export function toKoldbLink(input: string): string {
+export function toSamsaraLink(id: number): string {
   // NOTE: KOLDB does not support https. If this ever changes, this should change too.
-  return `http://www.koldb.com/player.php?name=${encodeURI(input)}`;
+  return `https://samsara.loathers.net/player/${id}`;
 }
 
 export function toMuseumLink(id: number): string {


### PR DESCRIPTION
Also, while we're here, don't hyperlink unascended players, as this makes both koldb and samsara sad