### PR TITLE
Handle KoL rollover gracefully

### DIFF
--- a/packages/kol.js/package.json
+++ b/packages/kol.js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kol.js",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "main": "src/index.ts",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/kol.js/src/Client.test.ts
+++ b/packages/kol.js/src/Client.test.ts
@@ -1,14 +1,7 @@
 import { describe, expect, it, test, vi } from "vitest";
 
-import { Client } from "./Client.js";
+import { AuthError, Client, RolloverError } from "./Client.js";
 import { loadFixture } from "./testUtils.js";
-
-vi.mock("./Client.js", async (importOriginal) => {
-  const client = await importOriginal<typeof import("./Client.js")>();
-  client.Client.prototype.login = async () => true;
-  client.Client.prototype.checkLoggedIn = async () => true;
-  return client;
-});
 
 function mockSession(fn: () => unknown) {
   return Object.assign(fn, {
@@ -202,14 +195,12 @@ describe("Familiars", () => {
 
     const familiars = await client.getFamiliars();
 
-    // Current
     expect(familiars).toContainEqual({
       id: 294,
       name: "Jill-of-All-Trades",
       image: "itemimages/darkjill2f.gif",
     });
 
-    // Problematic
     expect(familiars).toContainEqual({
       id: 278,
       name: "Left-Hand Man",
@@ -221,43 +212,60 @@ describe("Familiars", () => {
       image: "otherimages/camelfam_left.gif",
     });
 
-    // Just to be sure
     expect(familiars).toHaveLength(206);
   });
 });
 
 describe("fetchJson error handling", () => {
-  it("returns null on non-login errors instead of retrying", async () => {
+  it("throws on non-login errors", async () => {
     const client = new Client("", "");
+    vi.spyOn(client, "login").mockResolvedValue(true);
     client.session = mockSession(() => {
       throw new Error("500 Internal Server Error");
     });
-    expect(await client.fetchJson("api.php")).toBeNull();
+    await expect(client.fetchJson("api.php")).rejects.toThrow(
+      "500 Internal Server Error",
+    );
   });
 
-  it("returns fallback on non-login errors", async () => {
+  it("does not retry more than once on non-login errors", async () => {
     const client = new Client("", "");
-    client.session = mockSession(() => {
-      throw new Error("Parse error");
-    });
-    expect(await client.fetchJson("api.php", {}, "default")).toBe("default");
-  });
-
-  it("does not retry more than once", async () => {
-    const client = new Client("", "");
+    vi.spyOn(client, "login").mockResolvedValue(true);
     let calls = 0;
     client.session = mockSession(() => {
       calls++;
       throw new Error("persistent error");
     });
-    expect(await client.fetchJson("test.php", {}, null, true)).toBeNull();
+    await expect(client.fetchJson("test.php")).rejects.toThrow(
+      "persistent error",
+    );
     expect(calls).toBe(1);
+  });
+
+  it("propagates RolloverError", async () => {
+    const client = new Client("", "");
+    vi.spyOn(client, "login").mockResolvedValue(true);
+    client.session = mockSession(() => {
+      throw new RolloverError();
+    });
+    await expect(client.fetchJson("test.php")).rejects.toBeInstanceOf(
+      RolloverError,
+    );
+  });
+
+  it("throws AuthError when login fails", async () => {
+    const client = new Client("", "");
+    vi.spyOn(client, "login").mockResolvedValue(false);
+    await expect(client.fetchJson("test.php")).rejects.toBeInstanceOf(
+      AuthError,
+    );
   });
 });
 
 describe("fetchText error handling", () => {
   it("throws on non-login errors instead of retrying", async () => {
     const client = new Client("", "");
+    vi.spyOn(client, "login").mockResolvedValue(true);
     client.session = mockSession(() => {
       throw new Error("Network timeout");
     });
@@ -266,16 +274,170 @@ describe("fetchText error handling", () => {
     );
   });
 
-  it("does not retry more than once", async () => {
+  it("does not retry more than once on non-login errors", async () => {
     const client = new Client("", "");
+    vi.spyOn(client, "login").mockResolvedValue(true);
     let calls = 0;
     client.session = mockSession(() => {
       calls++;
       throw new Error("persistent error");
     });
-    await expect(
-      client.fetchText("test.php", {}, undefined, true),
-    ).rejects.toThrow("persistent error");
+    await expect(client.fetchText("test.php")).rejects.toThrow(
+      "persistent error",
+    );
     expect(calls).toBe(1);
+  });
+});
+
+describe("rollover handling", () => {
+  it("detects rollover from login.php response", async () => {
+    const client = new Client("", "");
+    client.session = mockSession(
+      () => "The system is currently down for nightly maintenance.",
+    );
+    await client.login();
+    expect(client.isRollover()).toBe(true);
+
+    // All fetch methods should fail fast
+    await expect(client.fetchText("test.php")).rejects.toBeInstanceOf(
+      RolloverError,
+    );
+    await expect(client.fetchJson("test.php")).rejects.toBeInstanceOf(
+      RolloverError,
+    );
+  });
+
+  it("fetchText throws RolloverError immediately when in rollover", async () => {
+    const client = new Client("", "");
+    client.session = mockSession(
+      () => "The system is currently down for nightly maintenance",
+    );
+    await client.login();
+
+    let sessionCalled = false;
+    client.session = mockSession(() => {
+      sessionCalled = true;
+      return "";
+    });
+    await expect(client.fetchText("test.php")).rejects.toBeInstanceOf(
+      RolloverError,
+    );
+    expect(sessionCalled).toBe(false);
+  });
+
+  it("fetchJson throws RolloverError immediately when in rollover", async () => {
+    const client = new Client("", "");
+    client.session = mockSession(
+      () => "The system is currently down for nightly maintenance",
+    );
+    await client.login();
+
+    let sessionCalled = false;
+    client.session = mockSession(() => {
+      sessionCalled = true;
+      return {};
+    });
+    await expect(client.fetchJson("test.php")).rejects.toBeInstanceOf(
+      RolloverError,
+    );
+    expect(sessionCalled).toBe(false);
+  });
+
+  it("recovers from rollover when server comes back", async () => {
+    vi.useFakeTimers();
+    const client = new Client("", "");
+
+    client.session = mockSession(
+      () => "The system is currently down for nightly maintenance",
+    );
+    await client.login();
+    expect(client.isRollover()).toBe(true);
+
+    client.session = mockSession(() => "<html>normal login page</html>");
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(client.isRollover()).toBe(false);
+    vi.useRealTimers();
+  });
+
+  it("emits rollover event after recovery when login succeeds", async () => {
+    vi.useFakeTimers();
+    const client = new Client("", "");
+
+    // Enter rollover
+    client.session = mockSession(
+      () => "The system is currently down for nightly maintenance",
+    );
+    await client.login();
+
+    // Recover: checkForRollover sees normal page, then login flow works
+    let callCount = 0;
+    client.session = mockSession(() => {
+      callCount++;
+      // Call 1: #checkForRollover fetches login.php (normal)
+      if (callCount === 1) return "<html>normal login page</html>";
+      // Call 2+: checkLoggedIn/login succeed
+      return { pwd: "abc123" };
+    });
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(client.isRollover()).toBe(false);
+
+    // login needs checkLoggedIn to FAIL first so it goes through the
+    // full login flow where the latch is checked. Make first checkLoggedIn
+    // fail (no session yet), then login POST + second checkLoggedIn succeed.
+    callCount = 0;
+    client.session = mockSession(() => {
+      callCount++;
+      // Call 1: checkLoggedIn → returns non-object (fails validation)
+      if (callCount === 1) return "<html>not logged in</html>";
+      // Call 2: login POST → success (no rollover pattern)
+      if (callCount === 2) return "<html>game frameset</html>";
+      // Call 3: second checkLoggedIn → success
+      return { pwd: "def456" };
+    });
+
+    const rolloverSpy = vi.fn();
+    client.on("rollover", rolloverSpy);
+    const loggedIn = await client.login();
+    expect(loggedIn).toBe(true);
+    expect(rolloverSpy).toHaveBeenCalledOnce();
+
+    vi.useRealTimers();
+  });
+
+  it("stays in rollover if server is unreachable", async () => {
+    vi.useFakeTimers();
+    const client = new Client("", "");
+
+    client.session = mockSession(
+      () => "The system is currently down for nightly maintenance",
+    );
+    await client.login();
+    expect(client.isRollover()).toBe(true);
+
+    client.session = mockSession(() => {
+      throw new Error("Network error");
+    });
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(client.isRollover()).toBe(true);
+
+    client.session = mockSession(() => "<html>normal login page</html>");
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(client.isRollover()).toBe(false);
+
+    vi.useRealTimers();
+  });
+
+  it("does not recurse through fetchText/login during rollover check", async () => {
+    const client = new Client("", "");
+    let sessionCallCount = 0;
+    client.session = mockSession(() => {
+      sessionCallCount++;
+      return "The system is currently down for nightly maintenance";
+    });
+
+    await client.login();
+    expect(sessionCallCount).toBeLessThanOrEqual(3);
   });
 });

--- a/packages/kol.js/src/Client.ts
+++ b/packages/kol.js/src/Client.ts
@@ -29,6 +29,20 @@ export type MallPrice = {
 
 class LoginRedirectError extends Error {}
 
+export class RolloverError extends Error {
+  constructor() {
+    super("Kingdom of Loathing is currently down for rollover");
+    this.name = "RolloverError";
+  }
+}
+
+export class AuthError extends Error {
+  constructor() {
+    super("Unable to log in to Kingdom of Loathing");
+    this.name = "AuthError";
+  }
+}
+
 type FormData = Record<string, string | number | boolean>;
 
 type RequestOptions = {
@@ -88,8 +102,7 @@ export class Client extends Emittery<Events> {
         }
       },
       onResponse: ({ request, response }) => {
-        const requestUrl =
-          typeof request === "string" ? request : request.url;
+        const requestUrl = typeof request === "string" ? request : request.url;
         if (
           !requestUrl.includes("login.php") &&
           response.url.includes("/login.php")
@@ -105,11 +118,12 @@ export class Client extends Emittery<Events> {
   #username: string;
   #password: string;
   #isRollover = false;
+  #rolloverCheckScheduled = false;
   #chatBotStarted = false;
   #pwd = "";
 
   private lastFetchedMessages = "0";
-  private postRolloverLatch = false;
+  #postRolloverLatch = false;
 
   constructor(username: string, password: string) {
     super();
@@ -121,54 +135,57 @@ export class Client extends Emittery<Events> {
     return this.#username;
   }
 
-  async fetchText(
-    path: string,
-    options: RequestOptions = {},
-    fallback?: string,
-    retried = false,
-  ): Promise<string> {
-    // With no pwd, try to log in
-    if (!this.#pwd && !(await this.login())) return fallback ?? "";
+  async #withReauth<T>(fn: () => Promise<T>): Promise<T> {
+    if (this.#isRollover) throw new RolloverError();
+    if (!this.#pwd && !(await this.login())) {
+      if (this.#isRollover) throw new RolloverError();
+      throw new AuthError();
+    }
 
+    for (let attempt = 0; attempt < 2; attempt++) {
+      try {
+        return await fn();
+      } catch (error) {
+        if (error instanceof RolloverError) throw error;
+        if (error instanceof LoginRedirectError && attempt === 0) {
+          this.#pwd = "";
+          if (!(await this.login())) {
+            if (this.#isRollover) throw new RolloverError();
+            throw new AuthError();
+          }
+          continue;
+        }
+        throw error;
+      }
+    }
+
+    throw new AuthError();
+  }
+
+  async fetchText(path: string, options: RequestOptions = {}): Promise<string> {
     const { form, ...rest } = options;
-
-    try {
-      return await this.session(path, {
+    return this.#withReauth(() =>
+      this.session(path, {
         method: "POST",
         ...rest,
         body: form ? formToBody(form) : undefined,
         responseType: "text",
-      });
-    } catch (error) {
-      if (retried || !(error instanceof LoginRedirectError)) throw error;
-      this.#pwd = "";
-      return this.fetchText(path, options, fallback, true);
-    }
+      }),
+    );
   }
 
   async fetchJson<Result>(
     path: string,
     options: RequestOptions = {},
-    fallback?: Result,
-    retried = false,
-  ): Promise<Result | null> {
-    if (!(await this.login())) return fallback ?? null;
-
+  ): Promise<Result> {
     const { form, ...rest } = options;
-
-    try {
-      return await this.session<Result>(path, {
+    return this.#withReauth(() =>
+      this.session<Result>(path, {
         ...rest,
         body: form ? formToBody(form) : undefined,
         responseType: "json",
-      });
-    } catch (error) {
-      if (retried || !(error instanceof LoginRedirectError)) {
-        return fallback ?? null;
-      }
-      this.#pwd = "";
-      return this.fetchJson(path, options, fallback, true);
-    }
+      }),
+    );
   }
 
   async login(): Promise<boolean> {
@@ -188,20 +205,21 @@ export class Client extends Emittery<Events> {
       });
 
       if (Client.#rolloverPattern.test(result)) {
-        throw new Error("It's rollover!");
+        throw new RolloverError();
       }
 
       if (!(await this.checkLoggedIn())) return false;
 
-      if (this.postRolloverLatch) {
-        this.postRolloverLatch = false;
+      if (this.#postRolloverLatch) {
+        this.#postRolloverLatch = false;
         this.emit("rollover", new Date());
       }
 
       return true;
     } catch (error) {
-      console.log("error", error);
-      // Login failed, let's check if it is due to rollover
+      if (!(error instanceof RolloverError)) {
+        console.error("Login failed:", error);
+      }
       await this.#checkForRollover();
       return false;
     }
@@ -227,33 +245,61 @@ export class Client extends Emittery<Events> {
   static #rolloverPattern =
     /The system is currently down for nightly maintenance/;
 
+  // Uses this.session directly to avoid recursion through fetchText → login
   async #checkForRollover() {
-    const isRollover = Client.#rolloverPattern.test(await this.fetchText(""));
+    try {
+      const html = await this.session("login.php", { responseType: "text" });
+      const isRollover = Client.#rolloverPattern.test(html);
 
-    if (this.#isRollover && !isRollover) {
-      // Set the post-rollover latch so the bot can react on next log in.
-      this.postRolloverLatch = true;
+      if (this.#isRollover && !isRollover) {
+        this.#postRolloverLatch = true;
+      }
+
+      this.#isRollover = isRollover;
+    } catch {
+      // Can't reach server — don't change rollover state
     }
 
-    this.#isRollover = isRollover;
-
-    if (this.#isRollover) {
-      // Rollover appears to be in progress. Check again in one minute.
-      setTimeout(() => this.#checkForRollover(), 60_000);
+    if (this.#isRollover && !this.#rolloverCheckScheduled) {
+      this.#rolloverCheckScheduled = true;
+      setTimeout(() => {
+        this.#rolloverCheckScheduled = false;
+        void this.#checkForRollover();
+      }, 60_000);
     }
   }
 
   async startChatBot() {
     if (this.#chatBotStarted) return;
-    await this.useChatMacro("/join talkie");
-    this.loopChatBot();
     this.#chatBotStarted = true;
+    this.on("rollover", () => void this.#joinChat());
+    await this.#joinChat();
+    this.loopChatBot().catch((error) => {
+      console.error("Chat bot stopped:", error);
+    });
+  }
+
+  async #joinChat() {
+    try {
+      await this.useChatMacro("/join talkie");
+    } catch (error) {
+      if (!(error instanceof RolloverError)) {
+        console.error("Failed to join chat:", error);
+      }
+    }
   }
 
   private async loopChatBot() {
     while (true) {
-      await Promise.all([this.checkMessages(), this.checkKmails()]);
-      await wait(3000);
+      try {
+        await Promise.all([this.checkMessages(), this.checkKmails()]);
+      } catch (error) {
+        if (error instanceof AuthError) throw error;
+        if (!(error instanceof RolloverError)) {
+          console.error("Chat bot loop error:", error);
+        }
+      }
+      await wait(this.#isRollover ? 60_000 : 3000);
     }
   }
 
@@ -267,9 +313,6 @@ export class Client extends Emittery<Events> {
         lasttime: this.lastFetchedMessages,
       },
     });
-
-    if (!newChatMessagesResponse || typeof newChatMessagesResponse !== "object")
-      return;
 
     this.lastFetchedMessages = newChatMessagesResponse["last"];
 
@@ -295,12 +338,10 @@ export class Client extends Emittery<Events> {
       });
   }
 
-  async fetchStatus(): Promise<ApiStatus | null> {
-    const api = await this.fetchJson<ApiStatus>("api.php", {
+  async fetchStatus(): Promise<ApiStatus> {
+    return this.fetchJson<ApiStatus>("api.php", {
       query: { what: "status", for: `${this.#username} bot` },
     });
-
-    return api;
   }
 
   async fetchKmails(): Promise<KmailMessage[]> {
@@ -311,7 +352,7 @@ export class Client extends Emittery<Events> {
       },
     });
 
-    if (!Array.isArray(kmails) || kmails.length === 0) return [];
+    if (kmails.length === 0) return [];
 
     return kmails.map((msg: KoLKmail) => ({
       id: Number(msg.id),
@@ -359,9 +400,9 @@ export class Client extends Emittery<Events> {
   async getUpdates() {
     const result = await this.sendChat("/updates");
     return [
-      ...(result?.output.matchAll(
+      ...result.output.matchAll(
         /<p><b>[A-za-z]+ \d+<\/b> - (.*?)(?=<p>(?:<b>|<hr>))/g,
-      ) ?? []),
+      ),
     ].map((m) => m[1]);
   }
 
@@ -461,7 +502,7 @@ export class Client extends Emittery<Events> {
       blueText: sanitiseBlueText(blueText?.groups?.description),
       effect: effect?.groups
         ? {
-            name: effect.groups?.name,
+            name: effect.groups?.effect,
             duration: Number(effect.groups?.duration) || 0,
             descid: effect.groups?.descid,
           }

--- a/packages/kol.js/src/LoathingDate.test.ts
+++ b/packages/kol.js/src/LoathingDate.test.ts
@@ -56,7 +56,9 @@ describe("gameDayFromRealDate", () => {
   });
   test("Real date records game day", () => {
     const realDate = new Date(Date.UTC(2026, 3, 1, 3, 29, 59));
-    expect(new LoathingDate(realDate).toRealDate().getTime()).toBe(new Date(Date.UTC(2026, 2, 31, 3, 30, 0)).getTime())
+    expect(new LoathingDate(realDate).toRealDate().getTime()).toBe(
+      new Date(Date.UTC(2026, 2, 31, 3, 30, 0)).getTime(),
+    );
   });
 });
 

--- a/packages/kol.js/src/LoathingDate.ts
+++ b/packages/kol.js/src/LoathingDate.ts
@@ -75,14 +75,20 @@ export class LoathingDate {
   static COLLISION = 1209; // June 3, 2006 — comet created Hamburglar
 
   static getDaysSinceEpoch(kolYear: number, kolMonth: number, kolDate: number) {
-    return (kolYear - 1) * 96 + kolMonth * 8 + (kolDate - 1) - LoathingDate.CALENDAR_OFFSET;
+    return (
+      (kolYear - 1) * 96 +
+      kolMonth * 8 +
+      (kolDate - 1) -
+      LoathingDate.CALENDAR_OFFSET
+    );
   }
 
   private static MS_PER_DAY = 24 * 60 * 60 * 1_000;
 
   static gameDayFromRealDate(realDate: Date) {
     return Math.floor(
-      (realDate.getTime() - LoathingDate.EPOCH.getTime()) / LoathingDate.MS_PER_DAY,
+      (realDate.getTime() - LoathingDate.EPOCH.getTime()) /
+        LoathingDate.MS_PER_DAY,
     );
   }
 
@@ -100,7 +106,11 @@ export class LoathingDate {
   constructor(gameday: number);
   constructor(realDate: Date);
   constructor(kolYear: number, kolMonth: number, kolDate: number);
-  constructor(first: Date | number = new Date(), kolMonth?: number, kolDate?: number) {
+  constructor(
+    first: Date | number = new Date(),
+    kolMonth?: number,
+    kolDate?: number,
+  ) {
     const gameday =
       first instanceof Date
         ? LoathingDate.gameDayFromRealDate(first)
@@ -109,7 +119,7 @@ export class LoathingDate {
           : first;
 
     this.#realDate = addDays(LoathingDate.EPOCH.getTime(), gameday);
-    this.#realDate.setUTCHours(LoathingDate.EPOCH.getUTCHours())
+    this.#realDate.setUTCHours(LoathingDate.EPOCH.getUTCHours());
     const calendarDay = gameday + LoathingDate.CALENDAR_OFFSET;
     this.#year = Math.floor(calendarDay / 96) + 1;
     this.#month = Math.floor((calendarDay % 96) / 8);
@@ -304,7 +314,8 @@ export class LoathingDate {
 
     const gameday = this.getDaysSinceEpoch();
     if (gameday === LoathingDate.BLACK_SUNDAY) holidays.add("Black Sunday");
-    if (gameday === LoathingDate.WHITE_WEDNESDAY) holidays.add("White Wednesday");
+    if (gameday === LoathingDate.WHITE_WEDNESDAY)
+      holidays.add("White Wednesday");
     if (gameday === LoathingDate.COLLISION) holidays.add("The Comet");
 
     const statDay = this.getStatDay();

--- a/packages/kol.js/src/Player.test.ts
+++ b/packages/kol.js/src/Player.test.ts
@@ -49,10 +49,7 @@ describe("Player.Profiled.parseProfile", () => {
   });
 
   test("Can parse a profile picture on dependence day", async () => {
-    const html = await loadFixture(
-      __dirname,
-      "showplayer_dependence_day.html",
-    );
+    const html = await loadFixture(__dirname, "showplayer_dependence_day.html");
     const result = await Player.Profiled.parseProfile(html);
 
     expectNotNull(result);

--- a/packages/kol.js/src/Player.ts
+++ b/packages/kol.js/src/Player.ts
@@ -36,9 +36,7 @@ export class Player {
 
   async isOnline(): Promise<boolean> {
     const response = await this.#client.useChatMacro(`/whois ${this.name}`);
-    return (
-      response?.output.includes("This player is currently online") ?? false
-    );
+    return response.output.includes("This player is currently online");
   }
 
   matches(identifier: string | number): boolean {
@@ -70,9 +68,7 @@ export class Player {
   }
 
   static parseNameFromWhois(html: string): string | null {
-    return (
-      html.match(/<a.*?><b.*?>(.*?) \(#(\d+)\)<\/b><\/a>/)?.[1] ?? null
-    );
+    return html.match(/<a.*?><b.*?>(.*?) \(#(\d+)\)<\/b><\/a>/)?.[1] ?? null;
   }
 }
 
@@ -130,14 +126,12 @@ export namespace Player {
             0,
         ),
         tattoos: Number(
-          html.match(/>Tattoos Collected:<\/b><\/td><td>(.*?)<\/td>/)?.[1] ??
-            0,
+          html.match(/>Tattoos Collected:<\/b><\/td><td>(.*?)<\/td>/)?.[1] ?? 0,
         ),
         favoriteFood:
           html.match(/>Favorite Food:<\/b><\/td><td>(.*?)<\/td>/)?.[1] ?? null,
         favoriteBooze:
-          html.match(/>Favorite Booze:<\/b><\/td><td>(.*?)<\/td>/)?.[1] ??
-          null,
+          html.match(/>Favorite Booze:<\/b><\/td><td>(.*?)<\/td>/)?.[1] ?? null,
         createdDate: parsePlayerDate(
           html.match(/>Account Created:<\/b><\/td><td>(.*?)<\/td>/)?.[1],
         ),

--- a/packages/kol.js/src/domains/ClanDungeon.ts
+++ b/packages/kol.js/src/domains/ClanDungeon.ts
@@ -15,26 +15,52 @@ export class RaidLogMissingError extends Error {
 }
 
 export type RaidLogEvent =
-  | { type: "kill"; playerName: string; playerId: number; monster: string; count: number; boss: boolean }
-  | { type: "defeat"; playerName: string; playerId: number; monster: string; count: number; boss: boolean }
-  | { type: "loot"; playerName: string; playerId: number; item: string; recipientName: string; recipientId: number };
+  | {
+      type: "kill";
+      playerName: string;
+      playerId: number;
+      monster: string;
+      count: number;
+      boss: boolean;
+    }
+  | {
+      type: "defeat";
+      playerName: string;
+      playerId: number;
+      monster: string;
+      count: number;
+      boss: boolean;
+    }
+  | {
+      type: "loot";
+      playerName: string;
+      playerId: number;
+      item: string;
+      recipientName: string;
+      recipientId: number;
+    };
 
 export const PLAYER_PREFIX = `([A-Za-z0-9\\-_ ]+)\\s+\\(#(\\d+)\\)\\s+`;
 
 const KILL_MULTI = new RegExp(
-  `^${PLAYER_PREFIX}defeated\\s+(.+?)\\s+x\\s+(\\d+)`, "i",
+  `^${PLAYER_PREFIX}defeated\\s+(.+?)\\s+x\\s+(\\d+)`,
+  "i",
 );
 const KILL_SINGLE = new RegExp(
-  `^${PLAYER_PREFIX}defeated\\s+(.+?)\\s+\\(1 turn\\)`, "i",
+  `^${PLAYER_PREFIX}defeated\\s+(.+?)\\s+\\(1 turn\\)`,
+  "i",
 );
 const DEFEAT_MULTI = new RegExp(
-  `^${PLAYER_PREFIX}was defeated by\\s+(.+?)\\s+x\\s+(\\d+)`, "i",
+  `^${PLAYER_PREFIX}was defeated by\\s+(.+?)\\s+x\\s+(\\d+)`,
+  "i",
 );
 const DEFEAT_SINGLE = new RegExp(
-  `^${PLAYER_PREFIX}was defeated by\\s+(.+?)\\s+\\(1 turn\\)`, "i",
+  `^${PLAYER_PREFIX}was defeated by\\s+(.+?)\\s+\\(1 turn\\)`,
+  "i",
 );
 const LOOT = new RegExp(
-  `^${PLAYER_PREFIX}distributed\\s+(.+?)\\s+to\\s+(.+?)\\s+\\(#(\\d+)\\)`, "i",
+  `^${PLAYER_PREFIX}distributed\\s+(.+?)\\s+to\\s+(.+?)\\s+\\(#(\\d+)\\)`,
+  "i",
 );
 
 function matchKill(line: string, bossNames: string[]): RaidLogEvent | null {
@@ -47,7 +73,9 @@ function matchKill(line: string, bossNames: string[]): RaidLogEvent | null {
       playerId: parseInt(multi[2]),
       monster,
       count: parseInt(multi[4]),
-      boss: bossNames.some((b) => monster.toLowerCase().includes(b.toLowerCase())),
+      boss: bossNames.some((b) =>
+        monster.toLowerCase().includes(b.toLowerCase()),
+      ),
     };
   }
 
@@ -60,7 +88,9 @@ function matchKill(line: string, bossNames: string[]): RaidLogEvent | null {
       playerId: parseInt(single[2]),
       monster,
       count: 1,
-      boss: bossNames.some((b) => monster.toLowerCase().includes(b.toLowerCase())),
+      boss: bossNames.some((b) =>
+        monster.toLowerCase().includes(b.toLowerCase()),
+      ),
     };
   }
 
@@ -77,7 +107,9 @@ function matchDefeat(line: string, bossNames: string[]): RaidLogEvent | null {
       playerId: parseInt(multi[2]),
       monster,
       count: parseInt(multi[4]),
-      boss: bossNames.some((b) => monster.toLowerCase().includes(b.toLowerCase())),
+      boss: bossNames.some((b) =>
+        monster.toLowerCase().includes(b.toLowerCase()),
+      ),
     };
   }
 
@@ -90,7 +122,9 @@ function matchDefeat(line: string, bossNames: string[]): RaidLogEvent | null {
       playerId: parseInt(single[2]),
       monster,
       count: 1,
-      boss: bossNames.some((b) => monster.toLowerCase().includes(b.toLowerCase())),
+      boss: bossNames.some((b) =>
+        monster.toLowerCase().includes(b.toLowerCase()),
+      ),
     };
   }
 
@@ -114,7 +148,10 @@ function matchLoot(line: string): RaidLogEvent | null {
  * Try to parse a single stripped log line into a base raid log event.
  * Returns null if the line doesn't match any known pattern.
  */
-export function parseLine(line: string, bossNames: string[]): RaidLogEvent | null {
+export function parseLine(
+  line: string,
+  bossNames: string[],
+): RaidLogEvent | null {
   return (
     matchKill(line, bossNames) ??
     matchDefeat(line, bossNames) ??
@@ -155,10 +192,7 @@ export class ClanDungeon {
     });
   }
 
-  async getRaidIds(
-    clanId: number,
-    exclude: number[] = [],
-  ): Promise<number[]> {
+  async getRaidIds(clanId: number, exclude: number[] = []): Promise<number[]> {
     return await this.#client.actionMutex.runExclusive(async () => {
       if (!(await this.#client.joinClan(clanId))) throw new JoinClanError();
       let raidLogs = await this.#client.fetchText("clan_oldraidlogs.php");

--- a/packages/kol.js/src/domains/Dreadsylvania.test.ts
+++ b/packages/kol.js/src/domains/Dreadsylvania.test.ts
@@ -33,7 +33,9 @@ describe("overview", () => {
 
     test("zone with no kills has 1000 remaining", async () => {
       const log = await loadFixture(import.meta.dirname, "raidlog.html");
-      expect(new DreadsylvaniaRaid(log).getOverview().village.remaining).toBe(1000);
+      expect(new DreadsylvaniaRaid(log).getOverview().village.remaining).toBe(
+        1000,
+      );
     });
   });
 
@@ -45,7 +47,9 @@ describe("overview", () => {
     test.skip("false when not fixed", () => {
       // Needs a fixture with no fixed capacitor (none of ours have this)
       expect(
-        new DreadsylvaniaRaid(loadDreadFixture("no-capacitor.html")).getOverview().capacitor,
+        new DreadsylvaniaRaid(
+          loadDreadFixture("no-capacitor.html"),
+        ).getOverview().capacitor,
       ).toBe(false);
     });
   });
@@ -75,44 +79,61 @@ describe("boss detection", () => {
   });
 
   test("detects Falls-From-Sky", () => {
-    expect(dread("raid-218519.html").getBossStatus("forest"))
-      .toMatchObject({ name: "Falls-From-Sky", status: "defeated" });
+    expect(dread("raid-218519.html").getBossStatus("forest")).toMatchObject({
+      name: "Falls-From-Sky",
+      status: "defeated",
+    });
   });
 
   test("detects The Great Wolf of the Air", () => {
-    expect(dread("raid-218286.html").getBossStatus("forest"))
-      .toMatchObject({ name: "The Great Wolf of the Air", status: "defeated" });
+    expect(dread("raid-218286.html").getBossStatus("forest")).toMatchObject({
+      name: "The Great Wolf of the Air",
+      status: "defeated",
+    });
   });
 
   test("detects The Zombie Homeowners' Association", () => {
-    expect(dread("raid-218519.html").getBossStatus("village"))
-      .toMatchObject({ name: "The Zombie Homeowners' Association", status: "defeated" });
+    expect(dread("raid-218519.html").getBossStatus("village")).toMatchObject({
+      name: "The Zombie Homeowners' Association",
+      status: "defeated",
+    });
   });
 
   test("detects Count Drunkula", () => {
-    expect(dread("raid-218519.html").getBossStatus("castle"))
-      .toMatchObject({ name: "Count Drunkula", status: "defeated" });
+    expect(dread("raid-218519.html").getBossStatus("castle")).toMatchObject({
+      name: "Count Drunkula",
+      status: "defeated",
+    });
   });
 
   test("detects The Unkillable Skeleton", () => {
-    expect(dread("raid-218286.html").getBossStatus("castle"))
-      .toMatchObject({ name: "The Unkillable Skeleton", status: "defeated" });
+    expect(dread("raid-218286.html").getBossStatus("castle")).toMatchObject({
+      name: "The Unkillable Skeleton",
+      status: "defeated",
+    });
   });
 
   test("defeated bosses have confidence 1", () => {
-    expect(dread("raid-218519.html").getBossStatus("forest").confidence).toBe(1);
+    expect(dread("raid-218519.html").getBossStatus("forest").confidence).toBe(
+      1,
+    );
   });
 
   test("predicts boss from kill differential", async () => {
     const log = await loadFixture(import.meta.dirname, "raidlog.html");
     const boss = new DreadsylvaniaRaid(log).getBossStatus("castle");
-    expect(boss).toMatchObject({ name: "The Unkillable Skeleton", status: "predicted" });
+    expect(boss).toMatchObject({
+      name: "The Unkillable Skeleton",
+      status: "predicted",
+    });
     expect(boss.confidence).toBeGreaterThan(0.5);
   });
 
   test("detects Mayor Ghost", () => {
-    expect(dread("raid-217988.html").getBossStatus("village"))
-      .toMatchObject({ name: "Mayor Ghost", status: "defeated" });
+    expect(dread("raid-217988.html").getBossStatus("village")).toMatchObject({
+      name: "Mayor Ghost",
+      status: "defeated",
+    });
   });
 
   test("low-confidence prediction with few balanced kills", async () => {
@@ -125,62 +146,96 @@ describe("boss detection", () => {
 });
 
 describe("forest details", () => {
-  test("attic", () => expect(dread("raid-218286.html").getForestStatus().attic).toBe(true));
-  test("watchtower", () => expect(dread("raid-217988.html").getForestStatus().watchtower).toBe(true));
-  test("auditor badge", () => expect(dread("raid-218029.html").getForestStatus().auditor).toBe(true));
-  test("music box", () => expect(dread("raid-218286.html").getForestStatus().musicbox).toBe(true));
-  test("kiwi via 'knocked some fruit loose'", () => expect(dread("raid-218029.html").getForestStatus().kiwi).toBe(true));
-  test("kiwi via 'wasted some fruit'", () => expect(dread("raid-213013.html").getForestStatus().kiwi).toBe(true));
-  test("moon-amber", () => expect(dread("raid-218286.html").getForestStatus().amber).toBe(true));
+  test("attic", () =>
+    expect(dread("raid-218286.html").getForestStatus().attic).toBe(true));
+  test("watchtower", () =>
+    expect(dread("raid-217988.html").getForestStatus().watchtower).toBe(true));
+  test("auditor badge", () =>
+    expect(dread("raid-218029.html").getForestStatus().auditor).toBe(true));
+  test("music box", () =>
+    expect(dread("raid-218286.html").getForestStatus().musicbox).toBe(true));
+  test("kiwi via 'knocked some fruit loose'", () =>
+    expect(dread("raid-218029.html").getForestStatus().kiwi).toBe(true));
+  test("kiwi via 'wasted some fruit'", () =>
+    expect(dread("raid-213013.html").getForestStatus().kiwi).toBe(true));
+  test("moon-amber", () =>
+    expect(dread("raid-218286.html").getForestStatus().amber).toBe(true));
 
   test("nothing unlocked", () => {
     expect(dread("cdr1-current.html").getForestStatus()).toEqual({
-      attic: false, watchtower: false, auditor: false,
-      musicbox: false, kiwi: false, amber: false,
+      attic: false,
+      watchtower: false,
+      auditor: false,
+      musicbox: false,
+      kiwi: false,
+      amber: false,
     });
   });
 
   test("everything unlocked", () => {
     expect(dread("raid-217988.html").getForestStatus()).toEqual({
-      attic: true, watchtower: true, auditor: true,
-      musicbox: true, kiwi: true, amber: true,
+      attic: true,
+      watchtower: true,
+      auditor: true,
+      musicbox: true,
+      kiwi: true,
+      amber: true,
     });
   });
 });
 
 describe("village details", () => {
-  test("schoolhouse", () => expect(dread("cdr1-current.html").getVillageStatus().schoolhouse).toBe(true));
-  test("master suite", () => expect(dread("raid-218519.html").getVillageStatus().suite).toBe(true));
-  test("hanging via 'hung'", () => expect(dread("raid-218205.html").getVillageStatus().hanging).toBe(true));
+  test("schoolhouse", () =>
+    expect(dread("cdr1-current.html").getVillageStatus().schoolhouse).toBe(
+      true,
+    ));
+  test("master suite", () =>
+    expect(dread("raid-218519.html").getVillageStatus().suite).toBe(true));
+  test("hanging via 'hung'", () =>
+    expect(dread("raid-218205.html").getVillageStatus().hanging).toBe(true));
 
   test("only schoolhouse unlocked", () => {
     expect(dread("cdr2-current.html").getVillageStatus()).toEqual({
-      schoolhouse: true, suite: false, hanging: false,
+      schoolhouse: true,
+      suite: false,
+      hanging: false,
     });
   });
 
   test("everything unlocked", () => {
     expect(dread("raid-217988.html").getVillageStatus()).toEqual({
-      schoolhouse: true, suite: true, hanging: true,
+      schoolhouse: true,
+      suite: true,
+      hanging: true,
     });
   });
 });
 
 describe("castle details", () => {
-  test("lab", () => expect(dread("cdr1-current.html").getCastleStatus().lab).toBe(true));
-  test("roast beast", () => expect(dread("raid-218286.html").getCastleStatus().roast).toBe(true));
-  test("wax banana", () => expect(dread("raid-218286.html").getCastleStatus().banana).toBe(true));
-  test("stinking agaricus", () => expect(dread("raid-218029.html").getCastleStatus().agaricus).toBe(true));
+  test("lab", () =>
+    expect(dread("cdr1-current.html").getCastleStatus().lab).toBe(true));
+  test("roast beast", () =>
+    expect(dread("raid-218286.html").getCastleStatus().roast).toBe(true));
+  test("wax banana", () =>
+    expect(dread("raid-218286.html").getCastleStatus().banana).toBe(true));
+  test("stinking agaricus", () =>
+    expect(dread("raid-218029.html").getCastleStatus().agaricus).toBe(true));
 
   test("nothing unlocked except lab", () => {
     expect(dread("cdr1-current.html").getCastleStatus()).toEqual({
-      lab: true, roast: false, banana: false, agaricus: false,
+      lab: true,
+      roast: false,
+      banana: false,
+      agaricus: false,
     });
   });
 
   test("everything unlocked", () => {
     expect(dread("raid-217988.html").getCastleStatus()).toEqual({
-      lab: true, roast: true, banana: true, agaricus: true,
+      lab: true,
+      roast: true,
+      banana: true,
+      agaricus: true,
     });
   });
 });
@@ -188,35 +243,46 @@ describe("castle details", () => {
 describe("participation", () => {
   test("parses kills per player", async () => {
     const log = await loadFixture(import.meta.dirname, "raidlog.html");
-    expect(new DreadsylvaniaRaid(log).getParticipation()[2802400]).toHaveProperty("kills", 423);
+    expect(
+      new DreadsylvaniaRaid(log).getParticipation()[2802400],
+    ).toHaveProperty("kills", 423);
   });
 
   test("parses skill uses", async () => {
     const log = await loadFixture(import.meta.dirname, "raidlog.html");
-    expect(new DreadsylvaniaRaid(log).getParticipation()[3137318]).toHaveProperty("skills", 1);
+    expect(
+      new DreadsylvaniaRaid(log).getParticipation()[3137318],
+    ).toHaveProperty("skills", 1);
   });
 
   test("player with only skill use has 0 kills", async () => {
     const log = await loadFixture(import.meta.dirname, "raidlog.html");
-    expect(new DreadsylvaniaRaid(log).getParticipation()[3137318]).toHaveProperty("kills", 0);
+    expect(
+      new DreadsylvaniaRaid(log).getParticipation()[3137318],
+    ).toHaveProperty("kills", 0);
   });
 
   test("counts single kills, multi-kills, and boss kills", () => {
-    const totalKills = Object.values(dread("raid-218518.html").getParticipation())
-      .reduce((sum, { kills }) => sum + kills, 0);
+    const totalKills = Object.values(
+      dread("raid-218518.html").getParticipation(),
+    ).reduce((sum, { kills }) => sum + kills, 0);
     expect(totalKills).toBe(3003);
   });
 
   test("only counts Dread kills from combined page", async () => {
     const log = await loadFixture(import.meta.dirname, "raidlog.html");
-    const totalKills = Object.values(new DreadsylvaniaRaid(log).getParticipation())
-      .reduce((sum, { kills }) => sum + kills, 0);
+    const totalKills = Object.values(
+      new DreadsylvaniaRaid(log).getParticipation(),
+    ).reduce((sum, { kills }) => sum + kills, 0);
     expect(totalKills).toBe(511);
   });
 
   test("returns empty for non-Dread log", () => {
-    expect(Object.keys(new DreadsylvaniaRaid("<html>Not a raid</html>").getParticipation()))
-      .toHaveLength(0);
+    expect(
+      Object.keys(
+        new DreadsylvaniaRaid("<html>Not a raid</html>").getParticipation(),
+      ),
+    ).toHaveLength(0);
   });
 
   test("mergeParticipation accumulates same player across sources", () => {
@@ -231,10 +297,22 @@ describe("participation", () => {
 describe("predictBoss", () => {
   const MONSTERS = ["bugbear", "werewolf"] as const;
   function kills(monster: 0 | 1, count: number): DreadEvent {
-    return { type: "kill", playerName: "Test", playerId: 1, monster: MONSTERS[monster], count, boss: false };
+    return {
+      type: "kill",
+      playerName: "Test",
+      playerId: 1,
+      monster: MONSTERS[monster],
+      count,
+      boss: false,
+    };
   }
   function banish(monster: 0 | 1): DreadEvent {
-    return { type: "banish", playerName: "Test", playerId: 1, monster: MONSTERS[monster] };
+    return {
+      type: "banish",
+      playerName: "Test",
+      playerId: 1,
+      monster: MONSTERS[monster],
+    };
   }
   function predict(events: DreadEvent[]) {
     const raid = new DreadsylvaniaRaid("");
@@ -284,11 +362,15 @@ describe("predictBoss", () => {
   });
 
   test("kills after a banish equalises ratio are less informative", () => {
-    expect(predict([banish(0), kills(0, 50), kills(1, 50)]).confidence).toBeLessThan(0.75);
+    expect(
+      predict([banish(0), kills(0, 50), kills(1, 50)]).confidence,
+    ).toBeLessThan(0.75);
   });
 
   test("kills before banish use pre-banish ratio", () => {
-    expect(predict([kills(0, 300), kills(1, 200), banish(0)]).boss).toBe("bugbear");
+    expect(predict([kills(0, 300), kills(1, 200), banish(0)]).boss).toBe(
+      "bugbear",
+    );
   });
 
   test("works for village zone", () => {
@@ -304,8 +386,22 @@ describe("predictBoss", () => {
   test("works for castle zone", () => {
     const raid = new DreadsylvaniaRaid("");
     (raid as { events: DreadEvent[] }).events = [
-      { type: "kill", playerName: "Test", playerId: 1, monster: "vampire", count: 100, boss: false },
-      { type: "kill", playerName: "Test", playerId: 1, monster: "skeleton", count: 300, boss: false },
+      {
+        type: "kill",
+        playerName: "Test",
+        playerId: 1,
+        monster: "vampire",
+        count: 100,
+        boss: false,
+      },
+      {
+        type: "kill",
+        playerName: "Test",
+        playerId: 1,
+        monster: "skeleton",
+        count: 300,
+        boss: false,
+      },
     ];
     const p = raid.predictBoss("castle");
     expect(p.boss).toBe("skeleton");

--- a/packages/kol.js/src/domains/Dreadsylvania.ts
+++ b/packages/kol.js/src/domains/Dreadsylvania.ts
@@ -1,4 +1,9 @@
-import { ClanDungeon, PLAYER_PREFIX, parseLine, type RaidLogEvent } from "./ClanDungeon.js";
+import {
+  ClanDungeon,
+  PLAYER_PREFIX,
+  parseLine,
+  type RaidLogEvent,
+} from "./ClanDungeon.js";
 
 export type { RaidLogEvent };
 
@@ -91,8 +96,18 @@ const MONSTER_PAIRS: Record<DreadZone, readonly [MonsterType, MonsterType]> = {
 
 export type DreadEvent =
   | RaidLogEvent
-  | { type: "banish"; playerName: string; playerId: number; monster: MonsterType }
-  | { type: "learned_skill"; playerName: string; playerId: number; helpers: [string, string] }
+  | {
+      type: "banish";
+      playerName: string;
+      playerId: number;
+      monster: MonsterType;
+    }
+  | {
+      type: "learned_skill";
+      playerName: string;
+      playerId: number;
+      helpers: [string, string];
+    }
   | { type: "capacitor"; playerName: string; playerId: number }
   | { type: "noncombat"; action: string };
 
@@ -149,13 +164,16 @@ const MONSTER_PLURALS_PATTERN = ALL_MONSTER_TYPES.map(pluralise).join("|");
 const BOSS_NAMES_LIST = Object.values(BOSS_NAMES);
 
 const BANISH = new RegExp(
-  `^${PLAYER_PREFIX}drove some (${MONSTER_PLURALS_PATTERN}) out of the`, "i",
+  `^${PLAYER_PREFIX}drove some (${MONSTER_PLURALS_PATTERN}) out of the`,
+  "i",
 );
 const LEARNED_SKILL = new RegExp(
-  `^${PLAYER_PREFIX}used The Machine, assisted by (.+) and (.+)`, "i",
+  `^${PLAYER_PREFIX}used The Machine, assisted by (.+) and (.+)`,
+  "i",
 );
 const CAPACITOR = new RegExp(
-  `^${PLAYER_PREFIX}fixed The Machine \\(1 turn\\)`, "i",
+  `^${PLAYER_PREFIX}fixed The Machine \\(1 turn\\)`,
+  "i",
 );
 
 function parseNumber(input?: string): number {
@@ -206,9 +224,7 @@ function parseEvents(raidLog: string): DreadEvent[] {
   // Current raid pages combine all dungeons in separate divs.
   // Historical raid pages are single-dungeon and have a title like
   // "Dreadsylvania run, March 11, 2026".
-  const dreadBlock = raidLog.match(
-    /<div id='Dreadsylvania'>([\s\S]*?)<\/div>/,
-  );
+  const dreadBlock = raidLog.match(/<div id='Dreadsylvania'>([\s\S]*?)<\/div>/);
   if (!dreadBlock && !raidLog.includes("Dreadsylvania run,")) return [];
   const html = dreadBlock?.[1] ?? raidLog;
 
@@ -245,7 +261,9 @@ export class DreadsylvaniaRaid {
   }
 
   private hasAction(action: string): boolean {
-    return this.events.some((e) => e.type === "noncombat" && e.action === action);
+    return this.events.some(
+      (e) => e.type === "noncombat" && e.action === action,
+    );
   }
 
   // --- Boss prediction ---
@@ -305,8 +323,10 @@ export class DreadsylvaniaRaid {
     const finalM1H2 = Math.max(2 - banishesM1, 0);
     const finalM2H2 = Math.max(3 - banishesM2, 0);
 
-    const bossUnderH1 = finalM1H1 > finalM2H1 ? m1 : finalM2H1 > finalM1H1 ? m2 : null;
-    const bossUnderH2 = finalM1H2 > finalM2H2 ? m1 : finalM2H2 > finalM1H2 ? m2 : null;
+    const bossUnderH1 =
+      finalM1H1 > finalM2H1 ? m1 : finalM2H1 > finalM1H1 ? m2 : null;
+    const bossUnderH2 =
+      finalM1H2 > finalM2H2 ? m1 : finalM2H2 > finalM1H2 ? m2 : null;
 
     // If banishes are decisive (both hypotheses agree), no need for kill analysis
     if (bossUnderH1 !== null && bossUnderH1 === bossUnderH2) {
@@ -345,7 +365,8 @@ export class DreadsylvaniaRaid {
     // Posterior via log-sum-exp (equal prior)
     const maxLog = Math.max(logLikH1, logLikH2);
     const posteriorH1 = isFinite(maxLog)
-      ? Math.exp(logLikH1 - maxLog) / (Math.exp(logLikH1 - maxLog) + Math.exp(logLikH2 - maxLog))
+      ? Math.exp(logLikH1 - maxLog) /
+        (Math.exp(logLikH1 - maxLog) + Math.exp(logLikH2 - maxLog))
       : 0.5;
     const posteriorH2 = 1 - posteriorH1;
 
@@ -355,11 +376,17 @@ export class DreadsylvaniaRaid {
 
     if (bossUnderH1 === m1) pBossM1 += posteriorH1;
     else if (bossUnderH1 === m2) pBossM2 += posteriorH1;
-    else { pBossM1 += posteriorH1 * 0.5; pBossM2 += posteriorH1 * 0.5; }
+    else {
+      pBossM1 += posteriorH1 * 0.5;
+      pBossM2 += posteriorH1 * 0.5;
+    }
 
     if (bossUnderH2 === m1) pBossM1 += posteriorH2;
     else if (bossUnderH2 === m2) pBossM2 += posteriorH2;
-    else { pBossM1 += posteriorH2 * 0.5; pBossM2 += posteriorH2 * 0.5; }
+    else {
+      pBossM1 += posteriorH2 * 0.5;
+      pBossM2 += posteriorH2 * 0.5;
+    }
 
     if (pBossM1 >= pBossM2) {
       return { boss: m1, confidence: pBossM1 };
@@ -402,7 +429,9 @@ export class DreadsylvaniaRaid {
       /Your clan has defeated <b>(?<castle>[\d,]+)<\/b> monster\(s\) in the Castle/,
     );
 
-    const skillCount = this.events.filter((e) => e.type === "learned_skill").length;
+    const skillCount = this.events.filter(
+      (e) => e.type === "learned_skill",
+    ).length;
     const capacitor = this.events.some((e) => e.type === "capacitor");
 
     return {
@@ -474,7 +503,11 @@ export class DreadsylvaniaRaid {
     for (const event of this.events) {
       if (event.type !== "kill" && event.type !== "learned_skill") continue;
       const { playerId } = event;
-      const existing = participation[playerId] ?? { playerId, skills: 0, kills: 0 };
+      const existing = participation[playerId] ?? {
+        playerId,
+        skills: 0,
+        kills: 0,
+      };
 
       if (event.type === "kill") {
         existing.kills += event.count;
@@ -508,9 +541,10 @@ export class DreadsylvaniaDungeon extends ClanDungeon {
   async getRaid(clanId: number): Promise<DreadsylvaniaRaid>;
   async getRaid(clanId: number, raidId: number): Promise<DreadsylvaniaRaid>;
   async getRaid(clanId: number, raidId?: number): Promise<DreadsylvaniaRaid> {
-    const log = raidId !== undefined
-      ? await this.getRaidById(clanId, raidId)
-      : await this.getCurrentRaid(clanId);
+    const log =
+      raidId !== undefined
+        ? await this.getRaidById(clanId, raidId)
+        : await this.getCurrentRaid(clanId);
     return new DreadsylvaniaRaid(log);
   }
 }

--- a/packages/kol.js/src/domains/Familiar.ts
+++ b/packages/kol.js/src/domains/Familiar.ts
@@ -44,7 +44,10 @@ export function leprechaunMeatDrop(weight: number, power = 1): number {
  * Inverse of leprechaunMeatDrop — halves the target then uses the
  * fairy inverse since meat drop = 2 * fairy item drop.
  */
-export function leprechaunWeightForMeatDrop(modifier: number, power = 1): number {
+export function leprechaunWeightForMeatDrop(
+  modifier: number,
+  power = 1,
+): number {
   return fairyWeightForItemDrop(modifier / 2, power);
 }
 

--- a/packages/kol.js/src/domains/Players.ts
+++ b/packages/kol.js/src/domains/Players.ts
@@ -18,9 +18,7 @@ export class Players {
     if (!Number.isNaN(id) || typeof identifier === "number") {
       return this.#byId.get(id);
     }
-    const resolvedId = this.#nameToId.get(
-      String(identifier).toLowerCase(),
-    );
+    const resolvedId = this.#nameToId.get(String(identifier).toLowerCase());
     return resolvedId !== undefined ? this.#byId.get(resolvedId) : undefined;
   }
 
@@ -38,8 +36,7 @@ export class Players {
     const cached = this.#getCached(identifier);
     if (cached instanceof Player.Profiled) return cached;
 
-    const identity =
-      cached ?? (await this.#resolveUncached(identifier));
+    const identity = cached ?? (await this.#resolveUncached(identifier));
     if (!identity) return null;
 
     const html = await this.#client.fetchText("showplayer.php", {
@@ -74,9 +71,7 @@ export class Players {
     }
   }
 
-  async #resolveUncached(
-    identifier: string | number,
-  ): Promise<Player | null> {
+  async #resolveUncached(identifier: string | number): Promise<Player | null> {
     const id = Number(identifier);
 
     if (!Number.isNaN(id) || typeof identifier === "number") {

--- a/packages/kol.js/src/domains/Raffle.test.ts
+++ b/packages/kol.js/src/domains/Raffle.test.ts
@@ -28,6 +28,7 @@ describe("Raffle", () => {
     text.mockResolvedValueOnce("<!-- itemid: 4 -->");
     text.mockResolvedValueOnce("<!-- itemid: 4 -->");
     text.mockResolvedValueOnce("<!-- itemid: 4 -->");
+    json.mockResolvedValueOnce({ daynumber: "100" });
 
     const raffle = new Raffle(client);
     const result = await raffle.getRaffle();

--- a/packages/kol.js/src/domains/Raffle.ts
+++ b/packages/kol.js/src/domains/Raffle.ts
@@ -49,9 +49,7 @@ export class Raffle {
         : [],
     );
 
-    const { daynumber } = (await this.#client.fetchStatus()) ?? {
-      daynumber: "0",
-    };
+    const { daynumber } = await this.#client.fetchStatus();
 
     return {
       today: { first: first ?? null, second: second ?? null },

--- a/packages/kol.js/src/domains/WardrobeOMatic.ts
+++ b/packages/kol.js/src/domains/WardrobeOMatic.ts
@@ -328,13 +328,7 @@ const SHIRT_MATERIALS = [
   "wool",
 ];
 
-const SHIRT_MATERIAL_QUALITIES = [
-  "super",
-  "hyper",
-  "ultra",
-  "mega",
-  "reroll",
-];
+const SHIRT_MATERIAL_QUALITIES = ["super", "hyper", "ultra", "mega", "reroll"];
 
 const SHIRT_BASE_NAMES = [
   "t-shirt",
@@ -584,7 +578,8 @@ function generateItem(
   const rng = new RNG(seed);
 
   const imageNum = rng.mtRand.roll(1, 9);
-  const imagePrefix = slot === "hat" && imageNum === 9 ? "hw_hat" : SLOT_IMAGE_PREFIX[slot];
+  const imagePrefix =
+    slot === "hat" && imageNum === 9 ? "hw_hat" : SLOT_IMAGE_PREFIX[slot];
   const image = `${imagePrefix}${imageNum}`;
 
   let name: string;
@@ -632,8 +627,8 @@ export class WardrobeOMatic {
 
   async getWardrobe(): Promise<WardrobeItem[]> {
     const status = await this.#client.fetchStatus();
-    const gameday = Number(status?.daynumber ?? 0);
-    const playerLevel = Number(status?.level ?? 1);
+    const gameday = Number(status.daynumber);
+    const playerLevel = Number(status.level);
     return WardrobeOMatic.getWardrobe(gameday, playerLevel);
   }
 

--- a/packages/kol.js/src/index.ts
+++ b/packages/kol.js/src/index.ts
@@ -1,7 +1,12 @@
 export { Player, type ProfileData } from "./Player.js";
-export { Client, type MallPrice } from "./Client.js";
+export { AuthError, Client, type MallPrice, RolloverError } from "./Client.js";
 export { LoathingDate } from "./LoathingDate.js";
 export { statsForLevel, levelForMainstat, levelForSubstat } from "./stats.js";
 
-export { resolveKoLImage, cleanString, toWikiLink, parseKoLNumber } from "./utils/utils.js";
+export {
+  resolveKoLImage,
+  cleanString,
+  toWikiLink,
+  parseKoLNumber,
+} from "./utils/utils.js";
 export type { KmailItem, KoLMessage } from "./utils/kmail.js";

--- a/packages/oaf/src/clients/discord.ts
+++ b/packages/oaf/src/clients/discord.ts
@@ -25,10 +25,37 @@ import {
   codeBlock,
   userMention,
 } from "discord.js";
-import { resolveKoLImage } from "kol.js";
+import { AuthError, RolloverError, resolveKoLImage } from "kol.js";
 import { isErrorLike, serializeError } from "serialize-error";
 
 import { config } from "../config.js";
+
+function describeCommandError(error: unknown): {
+  reply: string;
+  alert: boolean;
+} {
+  if (error instanceof RolloverError) {
+    return {
+      reply:
+        "Kingdom of Loathing is currently down for its daily rollover (maintenance). This usually takes 3-10 minutes, please try again shortly!",
+      alert: false,
+    };
+  }
+
+  if (error instanceof AuthError) {
+    return {
+      reply:
+        "I was unable to log in to Kingdom of Loathing. This might be a temporary issue, please try again shortly!",
+      alert: true,
+    };
+  }
+
+  return {
+    reply:
+      "OAF recovered from a crash trying to process that command. This has been logged, but poke in #mafia-and-scripting if it keeps happening.",
+    alert: true,
+  };
+}
 
 function safeStringify(value: unknown): string {
   return JSON.stringify(value, (_key, v: unknown) =>
@@ -131,15 +158,16 @@ export class DiscordClient extends Client {
         try {
           await command.execute(interaction);
         } catch (error) {
-          await this.alert("Recovered from a crash", interaction, error);
-          const message =
-            "OAF recovered from a crash trying to process that command. This has been logged, but poke in #mafia-and-scripting if it keeps happening.";
+          const message = describeCommandError(error);
+          if (message.alert) {
+            await this.alert("Recovered from a crash", interaction, error);
+          }
           if (interaction.deferred) {
-            await interaction.editReply(message);
+            await interaction.editReply(message.reply);
           } else if (interaction.replied) {
-            await interaction.followUp(message);
+            await interaction.followUp(message.reply);
           } else {
-            await interaction.reply(message);
+            await interaction.reply(message.reply);
           }
         }
         return;
@@ -194,7 +222,6 @@ export class DiscordClient extends Client {
       console.error(description);
     }
 
-
     if (config.DEBUG) {
       return;
     }
@@ -239,7 +266,10 @@ export class DiscordClient extends Client {
 
     const alert: MessageCreateOptions = {
       ...(typeof content === "string" ? { content } : content),
-      embeds: [...(typeof content === "string" ? [] : content.embeds ?? []), ...embeds],
+      embeds: [
+        ...(typeof content === "string" ? [] : (content.embeds ?? [])),
+        ...embeds,
+      ],
       allowedMentions: { users: [] },
     };
 

--- a/packages/oaf/src/commands/clan/status.ts
+++ b/packages/oaf/src/commands/clan/status.ts
@@ -25,7 +25,8 @@ async function constructDreadStatusMessage(): Promise<{
       const raid = await dungeon.getRaid(clan.id);
       const overview = raid.getOverview();
 
-      const skills = overview.castle.remaining > 0 ? overview.remainingSkills : 0;
+      const skills =
+        overview.castle.remaining > 0 ? overview.remainingSkills : 0;
 
       const capacitorString = overview.capacitor
         ? `${pluralize(skills, "skill")} left`
@@ -82,29 +83,37 @@ export const data = new SlashCommandBuilder()
 export function init() {
   kolClient.on("rollover", () => {
     void (async () => {
-      const { messages, pingableClans } = await constructDreadStatusMessage();
-      const channel = discordClient.guild?.channels.cache.get(
-        config.DUNGEON_CHANNEL_ID,
-      );
-      if (!channel?.isTextBased()) {
-        await discordClient.alert("No clan dungeon channel found");
-      } else {
-        await channel.send({
-          ...(pingableClans.length
-            ? {
-                content: `${roleMention(config.DUNGEON_MASTER_ROLE_ID)}, looks like ${pingableClans.join(" and ")} ${pingableClans.length === 1 ? "is" : "are"} ready to rock (and roll).`,
-              }
-            : {}),
-          embeds: [
-            {
-              title: "Dread Status",
-              description: messages.join("\n"),
+      try {
+        const { messages, pingableClans } = await constructDreadStatusMessage();
+        const channel = discordClient.guild?.channels.cache.get(
+          config.DUNGEON_CHANNEL_ID,
+        );
+        if (!channel?.isTextBased()) {
+          await discordClient.alert("No clan dungeon channel found");
+        } else {
+          await channel.send({
+            ...(pingableClans.length
+              ? {
+                  content: `${roleMention(config.DUNGEON_MASTER_ROLE_ID)}, looks like ${pingableClans.join(" and ")} ${pingableClans.length === 1 ? "is" : "are"} ready to rock (and roll).`,
+                }
+              : {}),
+            embeds: [
+              {
+                title: "Dread Status",
+                description: messages.join("\n"),
+              },
+            ],
+            allowedMentions: {
+              roles: [config.DUNGEON_MASTER_ROLE_ID],
             },
-          ],
-          allowedMentions: {
-            roles: [config.DUNGEON_MASTER_ROLE_ID],
-          },
-        });
+          });
+        }
+      } catch (error) {
+        await discordClient.alert(
+          "Failed to post dread status after rollover",
+          undefined,
+          error,
+        );
       }
     })();
   });

--- a/packages/oaf/src/commands/kol/raffle.ts
+++ b/packages/oaf/src/commands/kol/raffle.ts
@@ -32,7 +32,7 @@ const kolRaffle = new Raffle(kolClient);
 
 export async function execute(interaction: ChatInputCommandInteraction) {
   await interaction.deferReply({ flags: [MessageFlags.Ephemeral] });
-  const { daynumber } = (await kolClient.fetchStatus()) ?? { daynumber: "0" };
+  const { daynumber } = await kolClient.fetchStatus();
   const raffle = await findRaffle(Number(daynumber));
 
   if (!raffle) {
@@ -164,7 +164,7 @@ export async function postRaffleOnRollover(): Promise<{
   channelId: string;
   id: string;
 } | null> {
-  const { daynumber } = (await kolClient.fetchStatus()) ?? { daynumber: "0" };
+  const { daynumber } = await kolClient.fetchStatus();
   const existing = await findRaffle(Number(daynumber));
 
   if (existing) {

--- a/packages/oaf/src/commands/misc/daily.ts
+++ b/packages/oaf/src/commands/misc/daily.ts
@@ -9,16 +9,16 @@ import {
   italic,
   messageLink,
 } from "discord.js";
-
 import { LoathingDate } from "kol.js";
+import { toWikiLink } from "kol.js";
+
 import { getBirthdays, setGlobalsMessage } from "../../clients/database.js";
 import { discordClient } from "../../clients/discord.js";
 import { kolClient } from "../../clients/kol.js";
 import { config } from "../../config.js";
 import type { Player } from "../../database-types.js";
-import { renderSvg } from "../../svgConverter.js";
 import { formatPlayer } from "../../discordUtils.js";
-import { toWikiLink } from "kol.js";
+import { renderSvg } from "../../svgConverter.js";
 import { englishJoin, getRandom } from "../../utils.js";
 import { postRaffleOnRollover } from "../kol/raffle.js";
 import { buildGlobals } from "./_globals.js";
@@ -145,7 +145,9 @@ async function onRollover() {
     return;
   }
 
-  const adjective = LoathingDate.isAprilFools() ? 'foolish' : getRandom(ADJECTIVES);
+  const adjective = LoathingDate.isAprilFools()
+    ? "foolish"
+    : getRandom(ADJECTIVES);
   const titleMessage = await buildTitleMessage(adjective);
   await channel.send({ ...titleMessage, allowedMentions: { users: [] } });
 
@@ -165,7 +167,10 @@ async function onRollover() {
 
   for (const message of messages) {
     if (!message) continue;
-    const sentMessage = await channel.send({ ...message, allowedMentions: { users: [] } });
+    const sentMessage = await channel.send({
+      ...message,
+      allowedMentions: { users: [] },
+    });
     await sentMessage.crosspost();
   }
 
@@ -201,5 +206,17 @@ export async function execute(interaction: ChatInputCommandInteraction) {
 }
 
 export function init() {
-  kolClient.on("rollover", () => void onRollover());
+  kolClient.on("rollover", () => {
+    void (async () => {
+      try {
+        await onRollover();
+      } catch (error) {
+        await discordClient.alert(
+          "Failed to post newsletter after rollover",
+          undefined,
+          error,
+        );
+      }
+    })();
+  });
 }


### PR DESCRIPTION
## Summary
- Add `RolloverError` and `AuthError` as exported typed errors
- Extract `#withReauth` to centralise session expiry retry logic
- Fix `#checkForRollover` to avoid recursion through `fetchText`/`login`
- Remove fallback parameters — `fetchJson` returns `T` (not `T | null`), `fetchText` returns `string`
- Fail fast during rollover (no wasted network requests)
- Chat bot loop sleeps 60s during rollover, re-joins channel after recovery
- Guard against timer stacking with `#rolloverCheckScheduled` flag
- Discord commands show friendly rollover/auth messages instead of crash alerts
- Add try/catch to rollover event handlers in oaf
- Bump kol.js to 0.4.0 (breaking: fetchJson return type, removed fallback params)

## Test plan
- [x] Unit tests for rollover enter/exit/recovery lifecycle (fake timers)
- [x] Unit tests for RolloverError fail-fast in fetchText/fetchJson
- [x] Unit tests for AuthError on login failure
- [x] All 286 tests pass (157 kol.js + 129 oaf)
- [x] Vite client build succeeds
- [x] Multiple review rounds (staff/senior/junior/fresh eyes)