### PR TITLE
Emit rollover event directly from #checkForRollover

### DIFF
--- a/packages/kol.js/src/Client.test.ts
+++ b/packages/kol.js/src/Client.test.ts
@@ -360,7 +360,7 @@ describe("rollover handling", () => {
     vi.useRealTimers();
   });
 
-  it("emits rollover event after recovery when login succeeds", async () => {
+  it("emits rollover event when recovery is detected", async () => {
     vi.useFakeTimers();
     const client = new Client("", "");
 
@@ -369,38 +369,17 @@ describe("rollover handling", () => {
       () => "The system is currently down for nightly maintenance",
     );
     await client.login();
+    expect(client.isRollover()).toBe(true);
 
-    // Recover: checkForRollover sees normal page, then login flow works
-    let callCount = 0;
-    client.session = mockSession(() => {
-      callCount++;
-      // Call 1: #checkForRollover fetches login.php (normal)
-      if (callCount === 1) return "<html>normal login page</html>";
-      // Call 2+: checkLoggedIn/login succeed
-      return { pwd: "abc123" };
-    });
-
-    await vi.advanceTimersByTimeAsync(60_000);
-    expect(client.isRollover()).toBe(false);
-
-    // login needs checkLoggedIn to FAIL first so it goes through the
-    // full login flow where the latch is checked. Make first checkLoggedIn
-    // fail (no session yet), then login POST + second checkLoggedIn succeed.
-    callCount = 0;
-    client.session = mockSession(() => {
-      callCount++;
-      // Call 1: checkLoggedIn → returns non-object (fails validation)
-      if (callCount === 1) return "<html>not logged in</html>";
-      // Call 2: login POST → success (no rollover pattern)
-      if (callCount === 2) return "<html>game frameset</html>";
-      // Call 3: second checkLoggedIn → success
-      return { pwd: "def456" };
-    });
-
+    // Listen for rollover event
     const rolloverSpy = vi.fn();
     client.on("rollover", rolloverSpy);
-    const loggedIn = await client.login();
-    expect(loggedIn).toBe(true);
+
+    // Recover: #checkForRollover sees normal page → emits rollover event
+    client.session = mockSession(() => "<html>normal login page</html>");
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(client.isRollover()).toBe(false);
     expect(rolloverSpy).toHaveBeenCalledOnce();
 
     vi.useRealTimers();

--- a/packages/kol.js/src/Client.ts
+++ b/packages/kol.js/src/Client.ts
@@ -123,7 +123,6 @@ export class Client extends Emittery<Events> {
   #pwd = "";
 
   private lastFetchedMessages = "0";
-  #postRolloverLatch = false;
 
   constructor(username: string, password: string) {
     super();
@@ -210,11 +209,6 @@ export class Client extends Emittery<Events> {
 
       if (!(await this.checkLoggedIn())) return false;
 
-      if (this.#postRolloverLatch) {
-        this.#postRolloverLatch = false;
-        this.emit("rollover", new Date());
-      }
-
       return true;
     } catch (error) {
       if (!(error instanceof RolloverError)) {
@@ -252,12 +246,14 @@ export class Client extends Emittery<Events> {
       const isRollover = Client.#rolloverPattern.test(html);
 
       if (this.#isRollover && !isRollover) {
-        this.#postRolloverLatch = true;
+        this.#isRollover = false;
+        await this.emit("rollover", new Date());
+        return;
       }
 
       this.#isRollover = isRollover;
     } catch {
-      // Can't reach server — don't change rollover state
+      // Can't reach server or handler failed — don't change rollover state
     }
 
     if (this.#isRollover && !this.#rolloverCheckScheduled) {
@@ -382,7 +378,7 @@ export class Client extends Emittery<Events> {
   async checkKmails() {
     const kmails = await this.fetchKmails();
     await this.deleteKmails(kmails.map((k) => k.id));
-    kmails.forEach((m) => this.emit("kmail", m));
+    for (const m of kmails) await this.emit("kmail", m);
   }
 
   async sendChat(message: string) {


### PR DESCRIPTION
## Summary
- Remove `#postRolloverLatch` indirection — emit the rollover event directly when `#checkForRollover` detects recovery
- All handlers authenticate on demand via `#withReauth`, so no pre-login needed before emit
- Await kmail emits in `checkKmails` (was a floating promise)
- Simpler test for rollover event emission (no multi-phase login mock needed)

Depends on #292

## Test plan
- [x] All 286 tests pass (157 kol.js + 129 oaf)
- [x] Rollover recovery test verifies event fires from timer callback