### PR TITLE
Fix decorator runtime compatibility, remove SWC

### DIFF
--- a/packages/kol.js/src/Client.ts
+++ b/packages/kol.js/src/Client.ts
@@ -230,18 +230,16 @@ export class Client extends Emittery<Events> {
     );
   }
 
-  @deduplicate()
-  async logout(): Promise<void> {
+  logout = deduplicate(async (): Promise<void> => {
     try {
       await this.session("logout.php", { responseType: "text" });
     } catch (error) {
       if (!(error instanceof LoginRedirectError)) throw error;
     }
     this.#pwd = "";
-  }
+  });
 
-  @deduplicate()
-  async login(): Promise<boolean> {
+  login = deduplicate(async (): Promise<boolean> => {
     if (await this.checkLoggedIn()) return true;
     if (this.#isRollover) return false;
     try {
@@ -263,7 +261,7 @@ export class Client extends Emittery<Events> {
       console.error("Login failed:", error);
       return false;
     }
-  }
+  });
 
   isRollover() {
     return this.#isRollover;
@@ -282,8 +280,7 @@ export class Client extends Emittery<Events> {
     }
   }
 
-  @deduplicate()
-  async waitForRolloverEnd(): Promise<void> {
+  waitForRolloverEnd = deduplicate(async (): Promise<void> => {
     while (this.#isRollover) {
       await wait(this.rolloverCheckInterval);
       try {
@@ -292,7 +289,7 @@ export class Client extends Emittery<Events> {
         // Server unreachable during rollover
       }
     }
-  }
+  });
 
   protected get pollInterval() {
     return 3000;

--- a/packages/kol.js/src/LoathingDate.ts
+++ b/packages/kol.js/src/LoathingDate.ts
@@ -54,6 +54,7 @@ function getRealWorldHoliday(realDate: Date): string | undefined {
     ["0,1", "Festival of Jarlsberg"],
     ["1,14", "Valentine's Day"],
     ["2,17", "St. Sneaky Pete's Day"],
+    ["3,1", "April Fools Day"],
     [`${easterMonth},${easterDate}`, "Oyster Egg Day"],
     ["6,4", "Dependence Day"],
     ["9,31", "Halloween"],

--- a/packages/kol.js/src/LoathingDate.ts
+++ b/packages/kol.js/src/LoathingDate.ts
@@ -45,12 +45,14 @@ function getThanksgiving(year: number): number {
   return firstThursday + 21;
 }
 
-function getRealWorldHoliday(realDate: Date): string | undefined {
+function getRealWorldHolidays(realDate: Date): string[] {
   const year = realDate.getUTCFullYear();
   const [easterMonth, easterDate] = getEaster(year);
   const thanksgiving = getThanksgiving(year);
 
-  const realHolidays = new Map([
+  const key = `${realDate.getUTCMonth()},${realDate.getUTCDate()}`;
+
+  const realHolidays: [string, string][] = [
     ["0,1", "Festival of Jarlsberg"],
     ["1,14", "Valentine's Day"],
     ["2,17", "St. Sneaky Pete's Day"],
@@ -60,9 +62,9 @@ function getRealWorldHoliday(realDate: Date): string | undefined {
     ["9,31", "Halloween"],
     [`10,${thanksgiving}`, "Feast of Boris"],
     ["11,25", "Crimbo"],
-  ]);
+  ];
 
-  return realHolidays.get(`${realDate.getUTCMonth()},${realDate.getUTCDate()}`);
+  return realHolidays.filter(([k]) => k === key).map(([, v]) => v);
 }
 
 export class LoathingDate {
@@ -291,8 +293,7 @@ export class LoathingDate {
     const gameHoliday = GAME_HOLIDAYS.get(`${this.#month},${this.#date}`);
     if (gameHoliday) holidays.add(gameHoliday);
 
-    const realHoliday = getRealWorldHoliday(this.#realDate);
-    if (realHoliday) holidays.add(realHoliday);
+    for (const h of getRealWorldHolidays(this.#realDate)) holidays.add(h);
 
     // Combination holidays replace their components
     if (

--- a/packages/kol.js/src/utils/deduplicate.ts
+++ b/packages/kol.js/src/utils/deduplicate.ts
@@ -1,20 +1,38 @@
-export function deduplicate() {
+function wrap<This extends WeakKey, Args extends unknown[], Return>(
+  fn: (this: This, ...args: Args) => Promise<Return>,
+): (this: This, ...args: Args) => Promise<Return> {
+  const pending = new WeakMap<This, Promise<Return>>();
+  return function (this: This, ...args: Args) {
+    const existing = pending.get(this);
+    if (existing) return existing;
+    const promise = fn.call(this, ...args);
+    pending.set(this, promise);
+    return promise.finally(() => pending.delete(this));
+  };
+}
+
+/**
+ * Standalone wrapper for deduplicating an async method by instance.
+ *
+ *   private doLogin = deduplicate(async () => { ... });
+ */
+export function deduplicate<This extends WeakKey, Return>(
+  fn: (this: This) => Promise<Return>,
+): (this: This) => Promise<Return> {
+  return wrap(fn);
+}
+
+/**
+ * TC39 decorator form — ready for when runtimes support stage 3 decorators.
+ *
+ *   @deduplicateDecorator()
+ *   async login() { ... }
+ */
+export function deduplicateDecorator() {
   return function <This extends WeakKey, Args extends unknown[], Return>(
     target: (this: This, ...args: Args) => Promise<Return>,
     _context: ClassMethodDecoratorContext,
   ) {
-    const pending = new WeakMap<This, Promise<Return>>();
-    return async function (this: This, ...args: Args) {
-      const self = this;
-      const existing = pending.get(self);
-      if (existing) return existing;
-      const promise = target.call(this, ...args);
-      pending.set(self, promise);
-      try {
-        return await promise;
-      } finally {
-        pending.delete(self);
-      }
-    };
+    return wrap(target);
   };
 }

--- a/packages/kol.js/src/utils/deduplicate.ts
+++ b/packages/kol.js/src/utils/deduplicate.ts
@@ -2,12 +2,16 @@ function wrap<This extends WeakKey, Args extends unknown[], Return>(
   fn: (this: This, ...args: Args) => Promise<Return>,
 ): (this: This, ...args: Args) => Promise<Return> {
   const pending = new WeakMap<This, Promise<Return>>();
-  return function (this: This, ...args: Args) {
+  return async function (this: This, ...args: Args) {
     const existing = pending.get(this);
     if (existing) return existing;
     const promise = fn.call(this, ...args);
     pending.set(this, promise);
-    return promise.finally(() => pending.delete(this));
+    try {
+      return await promise;
+    } finally {
+      pending.delete(this);
+    }
   };
 }
 

--- a/packages/oaf/src/server/web/components/BouncingEmoji.tsx
+++ b/packages/oaf/src/server/web/components/BouncingEmoji.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useRef } from "react";
+
+type Particle = {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  emoji: string;
+  size: number;
+};
+
+const GRAVITY = 300;
+const DAMPING = 0.7;
+const EMOJIS = ["🥗", "🥒", "🥗"];
+
+export function BouncingEmoji() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    const canvas = canvasRef.current;
+    if (!container || !canvas) return;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const particles: Particle[] = EMOJIS.map((emoji) => ({
+      x: Math.random() * 60 + 10,
+      y: Math.random() * 20,
+      vx: (Math.random() - 0.5) * 100,
+      vy: 0,
+      emoji,
+      size: 14,
+    }));
+
+    let lastTime = 0;
+    let animId = 0;
+
+    function resize() {
+      const rect = container!.getBoundingClientRect();
+      canvas!.width = rect.width;
+      canvas!.height = rect.height;
+    }
+
+    resize();
+
+    function animate(time: number) {
+      const dt = Math.min((time - lastTime) / 1000, 0.05);
+      lastTime = time;
+
+      const w = canvas!.width;
+      const h = canvas!.height;
+
+      ctx!.clearRect(0, 0, w, h);
+
+      for (const p of particles) {
+        p.vy += GRAVITY * dt;
+        p.x += p.vx * dt;
+        p.y += p.vy * dt;
+
+        // Bounce off walls
+        if (p.x < p.size / 2) {
+          p.x = p.size / 2;
+          p.vx = Math.abs(p.vx) * DAMPING;
+        }
+        if (p.x > w - p.size / 2) {
+          p.x = w - p.size / 2;
+          p.vx = -Math.abs(p.vx) * DAMPING;
+        }
+
+        // Bounce off floor
+        if (p.y > h - p.size / 2) {
+          p.y = h - p.size / 2;
+          p.vy = -Math.abs(p.vy) * DAMPING;
+
+          // Add random horizontal kick to keep things lively
+          if (Math.abs(p.vy) < 30) {
+            p.vy = -(80 + Math.random() * 120);
+            p.vx = (Math.random() - 0.5) * 150;
+          }
+        }
+
+        // Bounce off ceiling
+        if (p.y < p.size / 2) {
+          p.y = p.size / 2;
+          p.vy = Math.abs(p.vy) * DAMPING;
+        }
+
+        ctx!.font = `${p.size}px serif`;
+        ctx!.textAlign = "center";
+        ctx!.textBaseline = "middle";
+        ctx!.fillText(p.emoji, p.x, p.y);
+      }
+
+      animId = requestAnimationFrame(animate);
+    }
+
+    animId = requestAnimationFrame(animate);
+
+    const observer = new ResizeObserver(resize);
+    observer.observe(container);
+
+    return () => {
+      cancelAnimationFrame(animId);
+      observer.disconnect();
+    };
+  }, []);
+
+  return (
+    <div
+      ref={containerRef}
+      style={{
+        position: "absolute",
+        inset: 0,
+        pointerEvents: "none",
+        overflow: "hidden",
+      }}
+    >
+      <canvas ref={canvasRef} />
+    </div>
+  );
+}

--- a/packages/oaf/src/server/web/components/GregorianCalendar.tsx
+++ b/packages/oaf/src/server/web/components/GregorianCalendar.tsx
@@ -1,5 +1,6 @@
 import { LoathingDate } from "kol.js";
 
+import { BouncingEmoji } from "./BouncingEmoji.js";
 import CalendarNav from "./CalendarNav.js";
 import { HOLIDAY_EMOJI } from "./holidayEmoji.js";
 
@@ -142,6 +143,7 @@ export default function GregorianCalendar({
                     {holidays.map((h) => HOLIDAY_EMOJI[h] ?? "🎉").join("")}
                   </span>
                 )}
+                {holidays.includes("April Fools Day") && <BouncingEmoji />}
               </div>
             );
           })}

--- a/packages/oaf/src/server/web/components/KolCalendar.tsx
+++ b/packages/oaf/src/server/web/components/KolCalendar.tsx
@@ -123,6 +123,7 @@ export default function KolCalendar({
                         {holidays.map((h) => HOLIDAY_EMOJI[h] ?? "🎉").join("")}
                       </span>
                     )}
+                    {holidays.includes("April Fools Day") && <BouncingEmoji />}
                   </div>
                 );
               })}

--- a/packages/oaf/src/server/web/components/KolCalendar.tsx
+++ b/packages/oaf/src/server/web/components/KolCalendar.tsx
@@ -1,6 +1,7 @@
 import { LoathingDate } from "kol.js";
 import React from "react";
 
+import { BouncingEmoji } from "./BouncingEmoji.js";
 import CalendarNav from "./CalendarNav.js";
 import { HOLIDAY_EMOJI } from "./holidayEmoji.js";
 

--- a/packages/oaf/src/server/web/components/holidayEmoji.ts
+++ b/packages/oaf/src/server/web/components/holidayEmoji.ts
@@ -2,6 +2,7 @@ export const HOLIDAY_EMOJI: Record<string, string> = {
   "Festival of Jarlsberg": "🪄",
   "Valentine's Day": "💕",
   "St. Sneaky Pete's Day": "🍺",
+  "April Fools Day": "🤡",
   "Oyster Egg Day": "🥚",
   "El Dia De Los Muertos Borrachos": "💀",
   "Generic Summer Holiday": "☀️",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7530,7 +7530,7 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A^5.9.3#optional!builtin<compat/typescript>":
   version: 5.9.3
-  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=8c6c40"
+  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=b45daf"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver

--- a/yarn.lock
+++ b/yarn.lock
@@ -7530,7 +7530,7 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A^5.9.3#optional!builtin<compat/typescript>":
   version: 5.9.3
-  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=b45daf"
+  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=8c6c40"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver


### PR DESCRIPTION
## Summary
- Replace `@deduplicate()` decorator syntax with `deduplicate(async () => ...)` wrapper since tsx/esbuild cannot transform TC39 decorators at runtime
- Keep decorator form exported as `deduplicateDecorator` for future use
- Remove unused `@swc-node/register` and `@swc/core` dependencies

## Test plan
- [x] All tests pass (160 kol.js + 133 oaf)
- [x] Types pass