### PR TITLE
OHLC bucketing and chart improvements for tulip ticker

### DIFF
--- a/packages/oaf/src/clients/database.ts
+++ b/packages/oaf/src/clients/database.ts
@@ -669,9 +669,28 @@ export async function getFlowerPriceHistoryBucketed(
       sql<Date>`date_trunc(${sql.lit(bucketInterval)}, "createdAt")`.as(
         "createdAt",
       ),
-      sql<number>`avg(red)::int`.as("red"),
-      sql<number>`avg(white)::int`.as("white"),
-      sql<number>`avg(blue)::int`.as("blue"),
+      sql<number>`(array_agg(red ORDER BY "createdAt" ASC))[1]::int`.as(
+        "redOpen",
+      ),
+      sql<number>`max(red)`.as("redHigh"),
+      sql<number>`min(red)`.as("redLow"),
+      sql<number>`(array_agg(red ORDER BY "createdAt" DESC))[1]::int`.as("red"),
+      sql<number>`(array_agg(white ORDER BY "createdAt" ASC))[1]::int`.as(
+        "whiteOpen",
+      ),
+      sql<number>`max(white)`.as("whiteHigh"),
+      sql<number>`min(white)`.as("whiteLow"),
+      sql<number>`(array_agg(white ORDER BY "createdAt" DESC))[1]::int`.as(
+        "white",
+      ),
+      sql<number>`(array_agg(blue ORDER BY "createdAt" ASC))[1]::int`.as(
+        "blueOpen",
+      ),
+      sql<number>`max(blue)`.as("blueHigh"),
+      sql<number>`min(blue)`.as("blueLow"),
+      sql<number>`(array_agg(blue ORDER BY "createdAt" DESC))[1]::int`.as(
+        "blue",
+      ),
     ])
     .where("createdAt", ">=", since)
     .groupBy(sql`date_trunc(${sql.lit(bucketInterval)}, "createdAt")`)

--- a/packages/oaf/src/server/apps/tulips/routes/prices.ts
+++ b/packages/oaf/src/server/apps/tulips/routes/prices.ts
@@ -20,7 +20,29 @@ pricesRouter.get("/", async (req, res) => {
 
   try {
     const prices = config.bucket
-      ? await getFlowerPriceHistoryBucketed(since, config.bucket)
+      ? (await getFlowerPriceHistoryBucketed(since, config.bucket)).map(
+          (row) => ({
+            createdAt: row.createdAt,
+            red: {
+              open: row.redOpen,
+              high: row.redHigh,
+              low: row.redLow,
+              close: row.red,
+            },
+            white: {
+              open: row.whiteOpen,
+              high: row.whiteHigh,
+              low: row.whiteLow,
+              close: row.white,
+            },
+            blue: {
+              open: row.blueOpen,
+              high: row.blueHigh,
+              low: row.blueLow,
+              close: row.blue,
+            },
+          }),
+        )
       : await getFlowerPriceHistory(since);
 
     res.set("Cache-Control", "public, max-age=60").json({ prices });

--- a/packages/oaf/src/server/apps/tulips/types.ts
+++ b/packages/oaf/src/server/apps/tulips/types.ts
@@ -2,6 +2,35 @@ import type { Duration } from "date-fns";
 
 export type Range = "1D" | "1W" | "1M" | "YTD" | "1Y" | "10Y";
 
+export function formatTime(dateStr: string, range: Range): string {
+  const date = new Date(dateStr);
+  switch (range) {
+    case "1D":
+      return date.toLocaleTimeString(undefined, {
+        hour: "numeric",
+        minute: "2-digit",
+      });
+    case "1W":
+      return date.toLocaleDateString(undefined, {
+        weekday: "short",
+        hour: "numeric",
+      });
+    case "1M":
+    case "YTD":
+      return date.toLocaleDateString(undefined, {
+        month: "short",
+        day: "numeric",
+        hour: "numeric",
+      });
+    case "1Y":
+    case "10Y":
+      return date.toLocaleDateString(undefined, {
+        month: "short",
+        year: "2-digit",
+      });
+  }
+}
+
 export const RANGES: Record<
   Range,
   { duration: Duration | "YTD"; bucket: "hour" | "day" | null }

--- a/packages/oaf/src/server/apps/tulips/web/App.tsx
+++ b/packages/oaf/src/server/apps/tulips/web/App.tsx
@@ -3,12 +3,26 @@ import { useCallback, useEffect, useState } from "react";
 import { RANGES, type Range } from "../types.js";
 import TulipCard from "./components/TulipCard.js";
 
+type OHLC = { open: number; high: number; low: number; close: number };
+type ColorValue = number | OHLC;
+
 type PriceEntry = {
-  red: number;
-  white: number;
-  blue: number;
+  red: ColorValue;
+  white: ColorValue;
+  blue: ColorValue;
   createdAt: string;
 };
+
+function isOHLC(v: ColorValue): v is OHLC {
+  return typeof v === "object";
+}
+
+function toClose(v: ColorValue): number;
+function toClose(v: ColorValue | null): number | null;
+function toClose(v: ColorValue | null): number | null {
+  if (v === null) return null;
+  return isOHLC(v) ? v.close : v;
+}
 
 const RANGE_KEYS = Object.keys(RANGES) as Range[];
 
@@ -126,12 +140,22 @@ export default function App() {
               color={t.color}
               dotColor={t.dotColor}
               dataKey={t.key}
-              current={current?.[t.key] ?? 0}
-              first={first?.[t.key] ?? null}
-              history={prices.map((p) => ({
-                time: formatTime(p.createdAt, range),
-                value: p[t.key],
-              }))}
+              current={toClose(current?.[t.key] ?? 0)}
+              first={toClose(first?.[t.key] ?? null)}
+              history={prices.map((p) => {
+                const v = p[t.key];
+                if (!isOHLC(v)) {
+                  return { time: formatTime(p.createdAt, range), value: v };
+                }
+                return {
+                  time: formatTime(p.createdAt, range),
+                  value: v.close,
+                  open: v.open,
+                  high: v.high,
+                  low: v.low,
+                  range: [v.low, v.high] satisfies [number, number],
+                };
+              })}
             />
           ))}
         </div>

--- a/packages/oaf/src/server/apps/tulips/web/App.tsx
+++ b/packages/oaf/src/server/apps/tulips/web/App.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 
-import { RANGES, type Range } from "../types.js";
+import { formatTime, RANGES, type Range } from "../types.js";
 import TulipCard from "./components/TulipCard.js";
 
 type OHLC = { open: number; high: number; low: number; close: number };
@@ -25,35 +25,6 @@ function toClose(v: ColorValue | null): number | null {
 }
 
 const RANGE_KEYS = Object.keys(RANGES) as Range[];
-
-function formatTime(dateStr: string, range: Range): string {
-  const date = new Date(dateStr);
-  switch (range) {
-    case "1D":
-      return date.toLocaleTimeString(undefined, {
-        hour: "numeric",
-        minute: "2-digit",
-      });
-    case "1W":
-      return date.toLocaleDateString(undefined, {
-        weekday: "short",
-        hour: "numeric",
-      });
-    case "1M":
-    case "YTD":
-      return date.toLocaleDateString(undefined, {
-        month: "short",
-        day: "numeric",
-        hour: "numeric",
-      });
-    case "1Y":
-    case "10Y":
-      return date.toLocaleDateString(undefined, {
-        month: "short",
-        year: "2-digit",
-      });
-  }
-}
 
 const tulips = [
   {
@@ -142,13 +113,14 @@ export default function App() {
               dataKey={t.key}
               current={toClose(current?.[t.key] ?? 0)}
               first={toClose(first?.[t.key] ?? null)}
+              range={range}
               history={prices.map((p) => {
                 const v = p[t.key];
                 if (!isOHLC(v)) {
-                  return { time: formatTime(p.createdAt, range), value: v };
+                  return { time: p.createdAt, value: v };
                 }
                 return {
-                  time: formatTime(p.createdAt, range),
+                  time: p.createdAt,
                   value: v.close,
                   open: v.open,
                   high: v.high,

--- a/packages/oaf/src/server/apps/tulips/web/App.tsx
+++ b/packages/oaf/src/server/apps/tulips/web/App.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 
-import { formatTime, RANGES, type Range } from "../types.js";
+import { RANGES, type Range, formatTime } from "../types.js";
 import TulipCard from "./components/TulipCard.js";
 
 type OHLC = { open: number; high: number; low: number; close: number };
@@ -100,6 +100,12 @@ export default function App() {
         )}
       </div>
       {error && <div className="error-state">{error}</div>}
+      {range === "10Y" && (
+        <p className="data-note">
+          Live collection started Aug 2025. Earlier data imported from previous
+          tools and may contain gaps.
+        </p>
+      )}
       {loading ? (
         <div className="loading-state">Loading...</div>
       ) : (
@@ -116,11 +122,13 @@ export default function App() {
               range={range}
               history={prices.map((p) => {
                 const v = p[t.key];
+                const ts = new Date(p.createdAt).getTime();
                 if (!isOHLC(v)) {
-                  return { time: p.createdAt, value: v };
+                  return { time: p.createdAt, timestamp: ts, value: v };
                 }
                 return {
                   time: p.createdAt,
+                  timestamp: ts,
                   value: v.close,
                   open: v.open,
                   high: v.high,

--- a/packages/oaf/src/server/apps/tulips/web/components/TulipCard.tsx
+++ b/packages/oaf/src/server/apps/tulips/web/components/TulipCard.tsx
@@ -102,18 +102,8 @@ export default function TulipCard({
                 x2="0"
                 y2="1"
               >
-                <stop offset="0%" stopColor={color} stopOpacity={0.2} />
-                <stop offset="100%" stopColor={color} stopOpacity={0} />
-              </linearGradient>
-              <linearGradient
-                id={`gradient-range-${dataKey}`}
-                x1="0"
-                y1="0"
-                x2="0"
-                y2="1"
-              >
-                <stop offset="0%" stopColor={color} stopOpacity={0.12} />
-                <stop offset="100%" stopColor={color} stopOpacity={0.04} />
+                <stop offset="0%" stopColor={color} stopOpacity={0.3} />
+                <stop offset="100%" stopColor={color} stopOpacity={0.15} />
               </linearGradient>
             </defs>
             <XAxis
@@ -169,9 +159,9 @@ export default function TulipCard({
                 type="stepAfter"
                 dataKey="range"
                 stroke={color}
-                strokeOpacity={0.2}
-                strokeWidth={0.5}
-                fill={`url(#gradient-range-${dataKey})`}
+                strokeOpacity={0.4}
+                strokeWidth={1}
+                fill={`url(#gradient-${dataKey})`}
                 dot={false}
                 isAnimationActive={false}
                 tooltipType="none"
@@ -182,8 +172,8 @@ export default function TulipCard({
               dataKey="value"
               stroke={color}
               strokeWidth={1.5}
-              fill={`url(#gradient-${dataKey})`}
-              dot={false}
+              fill="none"
+              dot={{ r: 1.5, fill: color, stroke: "none" }}
               isAnimationActive={false}
             />
           </AreaChart>

--- a/packages/oaf/src/server/apps/tulips/web/components/TulipCard.tsx
+++ b/packages/oaf/src/server/apps/tulips/web/components/TulipCard.tsx
@@ -8,6 +8,8 @@ import {
   type TooltipContentProps,
 } from "recharts";
 
+import { formatTime, type Range } from "../../types.js";
+
 const numberFormat = new Intl.NumberFormat();
 
 type RawEntry = { time: string; value: number };
@@ -31,6 +33,7 @@ export default function TulipCard({
   first,
   history,
   dataKey,
+  range,
 }: {
   name: string;
   color: string;
@@ -39,6 +42,7 @@ export default function TulipCard({
   first: number | null;
   history: HistoryEntry[];
   dataKey: string;
+  range: Range;
 }) {
   const bucketed = history.some(isOHLCEntry);
   const [high, low] = history.reduce<[number | null, number | null]>(
@@ -113,6 +117,7 @@ export default function TulipCard({
               axisLine={{ stroke: "#1a1a3e" }}
               interval="preserveStartEnd"
               minTickGap={40}
+              tickFormatter={(v: string) => formatTime(v, range)}
             />
             <YAxis
               domain={[
@@ -137,7 +142,18 @@ export default function TulipCard({
                 const entry: HistoryEntry = payload[0].payload;
                 return (
                   <div className="tulip-tooltip">
-                    <p className="tulip-tooltip-label">{entry.time}</p>
+                    <p className="tulip-tooltip-label">
+                      {new Date(entry.time).toLocaleDateString(undefined, {
+                        month: "short",
+                        day: "numeric",
+                        year: "numeric",
+                        ...(range === "1D" || range === "1W"
+                          ? { hour: "numeric", minute: "2-digit" }
+                          : range === "1M" || range === "YTD"
+                            ? { hour: "numeric" }
+                            : {}),
+                      })}
+                    </p>
                     {isOHLCEntry(entry) ? (
                       <p className="tulip-tooltip-value" style={{ color }}>
                         O: {numberFormat.format(entry.open)} H:{" "}

--- a/packages/oaf/src/server/apps/tulips/web/components/TulipCard.tsx
+++ b/packages/oaf/src/server/apps/tulips/web/components/TulipCard.tsx
@@ -1,18 +1,39 @@
+import { useMemo } from "react";
 import {
   Area,
   AreaChart,
   ResponsiveContainer,
   Tooltip,
+  type TooltipContentProps,
   XAxis,
   YAxis,
-  type TooltipContentProps,
 } from "recharts";
 
-import { formatTime, type Range } from "../../types.js";
+import { type Range, formatTime } from "../../types.js";
 
 const numberFormat = new Intl.NumberFormat();
 
-type RawEntry = { time: string; value: number };
+function insertGapMarkers(history: HistoryEntry[]) {
+  if (history.length < 2) return history;
+
+  const intervals = history
+    .slice(1)
+    .map((h, i) => h.timestamp - history[i].timestamp);
+  const sorted = [...intervals].sort((a, b) => a - b);
+  const median = sorted[Math.floor(sorted.length / 2)];
+  const threshold = median * 3;
+
+  const result: Record<string, unknown>[] = [];
+  for (let i = 0; i < history.length; i++) {
+    if (i > 0 && history[i].timestamp - history[i - 1].timestamp > threshold) {
+      result.push({ timestamp: history[i].timestamp - 1 });
+    }
+    result.push(history[i]);
+  }
+  return result;
+}
+
+type RawEntry = { time: string; timestamp: number; value: number };
 type OHLCEntry = RawEntry & {
   open: number;
   high: number;
@@ -45,6 +66,7 @@ export default function TulipCard({
   range: Range;
 }) {
   const bucketed = history.some(isOHLCEntry);
+  const chartData = useMemo(() => insertGapMarkers(history), [history]);
   const [high, low] = history.reduce<[number | null, number | null]>(
     ([hi, lo], entry) => {
       const pointHigh = isOHLCEntry(entry) ? entry.high : entry.value;
@@ -97,7 +119,7 @@ export default function TulipCard({
       </div>
       <div className="tulip-chart">
         <ResponsiveContainer width="100%" height={200}>
-          <AreaChart data={history}>
+          <AreaChart data={chartData}>
             <defs>
               <linearGradient
                 id={`gradient-${dataKey}`}
@@ -111,13 +133,17 @@ export default function TulipCard({
               </linearGradient>
             </defs>
             <XAxis
-              dataKey="time"
+              dataKey="timestamp"
+              type="number"
+              scale="time"
+              domain={["dataMin", "dataMax"]}
               tick={{ fill: "#4a4a6a", fontSize: 10 }}
               tickLine={false}
               axisLine={{ stroke: "#1a1a3e" }}
-              interval="preserveStartEnd"
               minTickGap={40}
-              tickFormatter={(v: string) => formatTime(v, range)}
+              tickFormatter={(v: number) =>
+                formatTime(new Date(v).toISOString(), range)
+              }
             />
             <YAxis
               domain={[

--- a/packages/oaf/src/server/apps/tulips/web/components/TulipCard.tsx
+++ b/packages/oaf/src/server/apps/tulips/web/components/TulipCard.tsx
@@ -5,9 +5,23 @@ import {
   Tooltip,
   XAxis,
   YAxis,
+  type TooltipContentProps,
 } from "recharts";
 
 const numberFormat = new Intl.NumberFormat();
+
+type RawEntry = { time: string; value: number };
+type OHLCEntry = RawEntry & {
+  open: number;
+  high: number;
+  low: number;
+  range: [number, number];
+};
+type HistoryEntry = RawEntry | OHLCEntry;
+
+function isOHLCEntry(e: HistoryEntry): e is OHLCEntry {
+  return "open" in e;
+}
 
 export default function TulipCard({
   name,
@@ -23,14 +37,19 @@ export default function TulipCard({
   dotColor: string;
   current: number;
   first: number | null;
-  history: { time: string; value: number }[];
+  history: HistoryEntry[];
   dataKey: string;
 }) {
+  const bucketed = history.some(isOHLCEntry);
   const [high, low] = history.reduce<[number | null, number | null]>(
-    ([hi, lo], { value }) => [
-      hi === null || value > hi ? value : hi,
-      lo === null || value < lo ? value : lo,
-    ],
+    ([hi, lo], entry) => {
+      const pointHigh = isOHLCEntry(entry) ? entry.high : entry.value;
+      const pointLow = isOHLCEntry(entry) ? entry.low : entry.value;
+      return [
+        hi === null || pointHigh > hi ? pointHigh : hi,
+        lo === null || pointLow < lo ? pointLow : lo,
+      ];
+    },
     [null, null],
   );
   const change = first !== null ? current - first : null;
@@ -86,6 +105,16 @@ export default function TulipCard({
                 <stop offset="0%" stopColor={color} stopOpacity={0.2} />
                 <stop offset="100%" stopColor={color} stopOpacity={0} />
               </linearGradient>
+              <linearGradient
+                id={`gradient-range-${dataKey}`}
+                x1="0"
+                y1="0"
+                x2="0"
+                y2="1"
+              >
+                <stop offset="0%" stopColor={color} stopOpacity={0.12} />
+                <stop offset="100%" stopColor={color} stopOpacity={0.04} />
+              </linearGradient>
             </defs>
             <XAxis
               dataKey="time"
@@ -97,8 +126,14 @@ export default function TulipCard({
             />
             <YAxis
               domain={[
-                (min: number) => Math.floor(min - (min * 0.05 || 1)),
-                (max: number) => Math.ceil(max + (max * 0.05 || 1)),
+                (min: number) => {
+                  const m = low !== null && low < min ? low : min;
+                  return Math.floor(m - (m * 0.05 || 1));
+                },
+                (max: number) => {
+                  const m = high !== null && high > max ? high : max;
+                  return Math.ceil(m + (m * 0.05 || 1));
+                },
               ]}
               tick={{ fill: "#4a4a6a", fontSize: 10 }}
               tickLine={false}
@@ -107,19 +142,41 @@ export default function TulipCard({
               tickFormatter={(v: number) => numberFormat.format(v)}
             />
             <Tooltip
-              contentStyle={{
-                background: "#1a1a2e",
-                border: "1px solid #2a2a4e",
-                borderRadius: "4px",
-                fontSize: "0.75rem",
+              content={({ active, payload }: TooltipContentProps) => {
+                if (!active || !payload?.length) return null;
+                const entry: HistoryEntry = payload[0].payload;
+                return (
+                  <div className="tulip-tooltip">
+                    <p className="tulip-tooltip-label">{entry.time}</p>
+                    {isOHLCEntry(entry) ? (
+                      <p className="tulip-tooltip-value" style={{ color }}>
+                        O: {numberFormat.format(entry.open)} H:{" "}
+                        {numberFormat.format(entry.high)} L:{" "}
+                        {numberFormat.format(entry.low)} C:{" "}
+                        {numberFormat.format(entry.value)} meat
+                      </p>
+                    ) : (
+                      <p className="tulip-tooltip-value" style={{ color }}>
+                        {numberFormat.format(entry.value)} meat
+                      </p>
+                    )}
+                  </div>
+                );
               }}
-              labelStyle={{ color: "#8892b0" }}
-              itemStyle={{ color }}
-              formatter={(value) => [
-                numberFormat.format(value as number),
-                "meat",
-              ]}
             />
+            {bucketed && (
+              <Area
+                type="stepAfter"
+                dataKey="range"
+                stroke={color}
+                strokeOpacity={0.2}
+                strokeWidth={0.5}
+                fill={`url(#gradient-range-${dataKey})`}
+                dot={false}
+                isAnimationActive={false}
+                tooltipType="none"
+              />
+            )}
             <Area
               type="stepAfter"
               dataKey="value"

--- a/packages/oaf/src/server/apps/tulips/web/style.css
+++ b/packages/oaf/src/server/apps/tulips/web/style.css
@@ -190,3 +190,20 @@ h1 {
 .recharts-tooltip-cursor {
   stroke: #2a2a4e;
 }
+
+.tulip-tooltip {
+  background: #1a1a2e;
+  border: 1px solid #2a2a4e;
+  border-radius: 4px;
+  padding: 0.5rem 0.625rem;
+  font-size: 0.75rem;
+}
+
+.tulip-tooltip-label {
+  color: #8892b0;
+  margin-bottom: 0.25rem;
+}
+
+.tulip-tooltip-value {
+  white-space: nowrap;
+}

--- a/packages/oaf/src/server/apps/tulips/web/style.css
+++ b/packages/oaf/src/server/apps/tulips/web/style.css
@@ -55,6 +55,14 @@ h1 {
   margin-bottom: 1rem;
 }
 
+.data-note {
+  text-align: center;
+  font-size: 0.7rem;
+  color: #4a4a6a;
+  margin-bottom: 0.75rem;
+  font-style: italic;
+}
+
 .range-btn {
   background: none;
   border: 1px solid transparent;


### PR DESCRIPTION
## Summary

- Replace `AVG()` bucketing with true OHLC (open/high/low/close) per color per bucket, using `array_agg` for open/close and `min`/`max` for low/high
- API nests OHLC as `{ open, high, low, close }` objects per color for bucketed data; type guards provide full type safety through the frontend with no `as` casts
- Chart shows a shaded high-low range band behind the close line on bucketed ranges (1M, YTD, 1Y, 10Y)
- Tooltip displays full OHLC values on bucketed data
- High/low stats now reflect true min/max, not averaged values
- Switch XAxis from categorical to numeric time scale so gaps in data appear as empty space
- Auto-detect data gaps (>3x median interval) and break the line across them
- Add data provenance note on 10Y view
- Unbucketed ranges (1D, 1W) are unchanged

## Test plan

- [ ] Check 1D and 1W ranges render as before (no range band, raw data points)
- [ ] Check 1M/YTD show hourly OHLC range bands with accurate high/low stats
- [ ] Check 1Y/10Y show daily OHLC with individual dots per data point
- [ ] Hover tooltips show OHLC on bucketed ranges, plain value on raw
- [ ] Verify gaps in 10Y data appear as empty space, not connected lines
- [ ] Verify 10Y data note is visible, hidden on other ranges