### PR TITLE
Add Clan domain

### DIFF
--- a/packages/kol.js/src/Client.ts
+++ b/packages/kol.js/src/Client.ts
@@ -467,22 +467,6 @@ export class Client extends Emittery<Events> {
     throw new JoinClanError(join.reason);
   }
 
-  async addToWhitelist(playerId: number, clanId: number): Promise<Result> {
-    return await this.actionMutex.runExclusive(async () => {
-      const join = await this.joinClan(clanId);
-      if (!join.success) return join;
-      await this.fetchText("clan_whitelist.php", {
-        query: {
-          addwho: playerId,
-          level: 2,
-          title: "",
-          action: "add",
-        },
-      });
-      return { success: true };
-    });
-  }
-
   async useFamiliar(familiarId: number): Promise<boolean> {
     const result = await this.fetchText("familiar.php", {
       query: {

--- a/packages/kol.js/src/domains/Clan.test.ts
+++ b/packages/kol.js/src/domains/Clan.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { Client } from "../Client.js";
+import { loadFixture } from "../testUtils.js";
+import { Clan } from "./Clan.js";
+
+describe("getInfo", () => {
+  const client = new Client("", "");
+  const clan = new Clan(client);
+
+  test("parses clan info from showclan page", async () => {
+    vi.spyOn(client, "fetchText").mockResolvedValueOnce(
+      await loadFixture(__dirname, "showclan_cdr1.html"),
+    );
+    expect(await clan.getInfo(2047008362)).toStrictEqual({
+      id: 2047008362,
+      name: "Collaborative Dungeon Running 1",
+      leader: { id: 1382257, name: "UberJew" },
+      credo: "Dungeon running managed by the Ascension Speed Society.  Management and coordination is done here: https://discord.gg/KphxvKa",
+    });
+  });
+});
+
+describe("transferLeadership", () => {
+  const client = new Client("", "");
+  const clan = new Clan(client);
+
+  test("success when leadership transferred", async () => {
+    vi.spyOn(client, "fetchText").mockResolvedValueOnce(
+      await loadFixture(__dirname, "clan_admin_changeleader_success.html"),
+    );
+    expect(await clan.transferLeadership(3366354)).toStrictEqual({ success: true });
+  });
+
+  test("failure with no admin rights", async () => {
+    vi.spyOn(client, "fetchText").mockResolvedValueOnce(
+      await loadFixture(__dirname, "clan_admin_changeleader_no_rights.html"),
+    );
+    expect(await clan.transferLeadership(3366354)).toStrictEqual({
+      success: false,
+      reason: "Insufficient clan admin rights",
+    });
+  });
+
+  test("failure with unknown response", async () => {
+    vi.spyOn(client, "fetchText").mockResolvedValueOnce(
+      await loadFixture(__dirname, "clan_admin_changeleader_failure.html"),
+    );
+    expect(await clan.transferLeadership(3366354)).toStrictEqual({
+      success: false,
+      reason: "Unknown",
+    });
+  });
+});

--- a/packages/kol.js/src/domains/Clan.ts
+++ b/packages/kol.js/src/domains/Clan.ts
@@ -1,0 +1,61 @@
+import type { Client } from "../Client.js";
+
+type Result = { success: true } | { success: false; reason: string };
+
+export type ClanInfo = {
+  id: number;
+  name: string;
+  leader: { id: number; name: string };
+  credo: string;
+};
+
+export class Clan {
+  #client: Client;
+
+  constructor(client: Client) {
+    this.#client = client;
+  }
+
+  async getInfo(clanId: number): Promise<ClanInfo | null> {
+    const html = await this.#client.fetchText("showclan.php", {
+      query: { whichclan: clanId },
+    });
+    const name = html.match(/<b style="color: white">([^<]+)<\/b>/)?.[1] ?? null;
+    const leaderMatch = html.match(/href="showplayer\.php\?who=(\d+)">([^<]+)<\/a><\/b>, Level/);
+    const credo = html.match(/<b>Credo:<\/b><br>([^<]+)/)?.[1]?.trim() ?? null;
+    const idMatch = html.match(/name=whichclan value=(\d+)/);
+    if (!name || !leaderMatch || !credo || !idMatch) return null;
+    return {
+      id: Number(idMatch[1]),
+      name,
+      leader: { id: Number(leaderMatch[1]), name: leaderMatch[2] },
+      credo,
+    };
+  }
+
+  async transferLeadership(playerId: number): Promise<Result> {
+    const result = await this.#client.fetchText("clan_admin.php", {
+      method: "POST",
+      form: { action: "changeleader", newleader: playerId, confirm: "on" },
+    });
+    if (result.includes("Leadership of clan transferred")) return { success: true };
+    if (result.trim() === "") return { success: false, reason: "Insufficient clan admin rights" };
+    return { success: false, reason: "Unknown" };
+  }
+
+  async addPlayerToWhitelist(playerId: number, clanId: number): Promise<Result> {
+    return await this.#client.actionMutex.runExclusive(async () => {
+      const join = await this.#client.joinClan(clanId);
+      if (!join.success) return join;
+      await this.#client.fetchText("clan_whitelist.php", {
+        query: {
+          addwho: playerId,
+          level: 2,
+          title: "",
+          action: "add",
+        },
+      });
+      return { success: true };
+    });
+  }
+}

--- a/packages/kol.js/src/domains/__fixtures__/clan_admin_changeleader_failure.html
+++ b/packages/kol.js/src/domains/__fixtures__/clan_admin_changeleader_failure.html
@@ -1,0 +1,2 @@
+<!-- synthetic: no real capture available for this case -->
+<html><body>Unknown error.</body></html>

--- a/packages/kol.js/src/domains/__fixtures__/clan_admin_changeleader_success.html
+++ b/packages/kol.js/src/domains/__fixtures__/clan_admin_changeleader_success.html
@@ -1,0 +1,10 @@
+<html><head>
+<script language=Javascript>
+<!--
+if (parent.frames.length == 0) location.href="game.php";
+//-->
+</script>
+</head>
+
+<body>
+<Center><table  width=95%  cellspacing=0 cellpadding=0><tr><td style="background-color: blue" align=center ><b style="color: white">Results:</b></td></tr><tr><td style="padding: 5px; border: 1px solid blue;"><center><table><tr><td>Leadership of clan transferred.  A leader is no longer you.</td></tr></table></center></td></tr><tr><td height=4></td></tr></table></centeR></body></html>

--- a/packages/kol.js/src/domains/__fixtures__/showclan_cdr1.html
+++ b/packages/kol.js/src/domains/__fixtures__/showclan_cdr1.html
@@ -1,0 +1,23 @@
+<html><head>
+<script language=Javascript>
+<!--
+if (parent.frames.length == -1) location.href="game.php";
+var actions = { "sendmessage.php" : { "action" : 1, "title" : "Send Message", "arg" : "toid" }, "town_sendgift.php" : { "action" : 1, "title" : "Send Gift", "arg" : "towho" }, "makeoffer.php" : { "action" : 1, "title" : "Propose Trade", "arg" : "towho" }, "mallstore.php" : { "action" : 1, "title" : "Mall Store", "arg" : "whichstore" }, "/./curse.php" : { "action" : 1, "title" : "Throw TP", "arg" : "whichitem=1923&targetplayer" }, "/msg" : { "action" : 3, "useid" : true, "query" : "Enter message to send to %:" } }
+var notchat = true;//-->
+</script>
+<script language=Javascript src="/images/scripts/jquery-1.3.1.min.js"></script>
+<script language=Javascript src='/images/scripts/rcm.20160406.js'></script>    <link rel="stylesheet" type="text/css" href="/images/styles.20230117d.css">
+<style type='text/css'>
+.faded {
+    zoom: 1;
+    filter: alpha(opacity=35);
+    opacity: 0.35;
+    -khtml-opacity: 0.35;
+    -moz-opacity: 0.35;
+}
+</style>
+
+<script language="Javascript" src="/basics.js"></script><link rel="stylesheet" href="/basics.1.css" /></head>
+
+<body>
+<div id='menu' class=rcm></div><centeR><table  width=95%  cellspacing=0 cellpadding=0><tr><td style="background-color: blue" align=center ><b style="color: white">Collaborative Dungeon Running 1</b></td></tr><tr><td style="padding: 5px; border: 1px solid blue;"><center><table><tr><td><center><table><tr><td valign=top>Leader:</td><td valign=top><b><a href="showplayer.php?who=1382257">UberJew</a></b>, Level 16 Turtle Tamer</td></tr></table><p><table width=80% border cellpadding=5><tr><td><center><b>Credo:</b><br>Dungeon running managed by the Ascension Speed Society.  Management and coordination is done here: https://discord.gg/KphxvKa</td></tr></table><p><b>Members:</b><table><tr><td></td><td align=center class=small><b>Name:</b></td><td align=center class=small><b>Title:</b></td><td align=center class=small><b>Level:</b></td></tr><tr><td valign=center></td><td class=small><b><a class=nounder href="showplayer.php?who=3578299">Sauceress Worldwalker</a></b>&nbsp;</td><td class=small>&nbsp;</td><td class=small>26</td></tR><tr><td valign=center></td><td class=small><b><a class=nounder href="showplayer.php?who=3006138">Augster</a></b>&nbsp;</td><td class=small>&nbsp;</td><td class=small>20 (H)</td></tR><tr><td valign=center></td><td class=small><b><a class=nounder href="showplayer.php?who=1382257">UberJew</a></b>&nbsp;</td><td class=small>&nbsp;</td><td class=small>16</td></tR><tr><td valign=center></td><td class=small><b><a class=nounder href="showplayer.php?who=1892250">MsLasagna</a></b>&nbsp;</td><td class=small>&nbsp;</td><td class=small>16</td></tR><tr><td valign=center></td><td class=small><b><a class=nounder href="showplayer.php?who=3317378">dread_pm</a></b>&nbsp;</td><td class=small>&nbsp;</td><td class=small>15</td></tR><tr><td valign=center></td><td class=small><b><a class=nounder href="showplayer.php?who=3317364">dread_sc</a></b>&nbsp;</td><td class=small>&nbsp;</td><td class=small>15</td></tR><tr><td valign=center></td><td class=small><b><a class=nounder href="showplayer.php?who=3366345">CDR1 Bot</a></b>&nbsp;</td><td class=small>&nbsp;</td><td class=small>3</td></tR></table><table width="80%"><tr></tr></table><p><form name=apply><input type=hidden name=pwd value='66d18b6d2a9f7135069d634c305f6a25'><input type=hidden name=whichclan value=2047008362><input type=hidden name=action value='joinclan'><input class=button type=submit value="Apply to this Clan"> (Confirm: <input type=checkbox name=confirm>)</form><p><b><font color=gray>+</font></b> = player is online, <b>+</b> = player is online and in chat.<p><b>Trophy Case:</b><p>This clan's trophy case contains the following objects:<center><table><tr><td colspan=2 height=2 bgcolor=black></td></tr><tr><td><img onClick='javascript:window.open("desc_clantrophy.php?whichtrophy=uos2wt8q7nbya88d","","height=200,width=300")' src="/images/itemimages/hole.gif" width=30 height=30 class=hand></td><td valign=center><b>Space Shadow</b> (1)</td></tr><tr><td colspan=2 height=2 bgcolor=black></td></tr></table></center></td></tr></table></center></td></tr><tr><td height=4></td></tr></table></center></body><script src="/onfocus.1.js"></script></html>

--- a/packages/oaf/src/clients/kol.ts
+++ b/packages/oaf/src/clients/kol.ts
@@ -1,8 +1,10 @@
 import { Client, type MallPrice, RolloverError } from "kol.js";
+import { Clan } from "kol.js/domains/Clan";
 
 import { config } from "../config.js";
 
 export const kolClient = new Client(config.KOL_USER, config.KOL_PASS);
+export const clan = new Clan(kolClient);
 
 export function assertNotRollover(): void {
   if (kolClient.isRollover()) throw new RolloverError();

--- a/packages/oaf/src/commands/clan/_clans.ts
+++ b/packages/oaf/src/commands/clan/_clans.ts
@@ -4,7 +4,7 @@ type Clan = {
   id: number;
 };
 
-export const DREAD_CLANS: Clan[] = [
+export const DUNGEON_RUNNING_CLANS: Clan[] = [
   {
     name: "Collaborative Dungeon Running 1",
     synonyms: ["cdr1", "1"],
@@ -17,7 +17,7 @@ export const DREAD_CLANS: Clan[] = [
   },
 ];
 
-export const NON_DREAD_CLANS: Clan[] = [
+export const DUNGEON_ADMIN_CLANS: Clan[] = [
   {
     name: "Collaborative Dungeon Running Central",
     synonyms: ["central"],
@@ -25,4 +25,4 @@ export const NON_DREAD_CLANS: Clan[] = [
   },
 ];
 
-export const ALL_CLANS = DREAD_CLANS.concat(NON_DREAD_CLANS);
+export const DUNGEON_CLANS = DUNGEON_RUNNING_CLANS.concat(DUNGEON_ADMIN_CLANS);

--- a/packages/oaf/src/commands/clan/clan.ts
+++ b/packages/oaf/src/commands/clan/clan.ts
@@ -19,7 +19,7 @@ import {
 import { createEmbed, discordClient } from "../../clients/discord.js";
 import { kolClient } from "../../clients/kol.js";
 import { pluralize } from "../../utils.js";
-import { DREAD_CLANS } from "./_clans.js";
+import { DUNGEON_RUNNING_CLANS } from "./_clans.js";
 
 const dungeon = new DreadsylvaniaDungeon(kolClient);
 
@@ -179,7 +179,7 @@ function parseCastleStatus(status: DetailedDreadStatus) {
 export async function execute(interaction: ChatInputCommandInteraction) {
   const clanName = interaction.options.getString("clan", true).toLowerCase();
 
-  const clan = DREAD_CLANS.find(
+  const clan = DUNGEON_RUNNING_CLANS.find(
     (clan) =>
       clan.name.toLowerCase() === clanName || clan.synonyms.includes(clanName),
   );
@@ -255,7 +255,7 @@ export async function execute(interaction: ChatInputCommandInteraction) {
 export async function autocomplete(interaction: AutocompleteInteraction) {
   const focusedValue = interaction.options.getFocused().toLowerCase();
 
-  const filtered = DREAD_CLANS.filter(
+  const filtered = DUNGEON_RUNNING_CLANS.filter(
     (clan) =>
       clan.name.toLowerCase().includes(focusedValue) ||
       clan.synonyms.some((s) => s.includes(focusedValue)),

--- a/packages/oaf/src/commands/clan/skills.ts
+++ b/packages/oaf/src/commands/clan/skills.ts
@@ -16,7 +16,7 @@ import { assertNotRollover, kolClient } from "../../clients/kol.js";
 import { columnsByMaxLength, formatPlayer } from "../../discordUtils.js";
 import { pluralize } from "../../utils.js";
 import { identifyPlayer } from "../_player.js";
-import { DREAD_CLANS } from "./_clans.js";
+import { DUNGEON_RUNNING_CLANS } from "./_clans.js";
 
 const dungeon = new DreadsylvaniaDungeon(kolClient);
 
@@ -34,7 +34,7 @@ export const data = new SlashCommandBuilder()
 
 async function getParticipationFromCurrentRaid() {
   return await Promise.all(
-    DREAD_CLANS.map(async (clan) => {
+    DUNGEON_RUNNING_CLANS.map(async (clan) => {
       const raid = await dungeon.getRaid(clan.id);
       return raid.getParticipation();
     }),
@@ -59,7 +59,7 @@ async function parseLogs() {
     }[];
   }[] = [];
 
-  for (const clan of DREAD_CLANS) {
+  for (const clan of DUNGEON_RUNNING_CLANS) {
     const raidIds = (await dungeon.getRaidIds(clan.id, parsedRaids)).filter(
       (id) => !parsedRaids.includes(id),
     );

--- a/packages/oaf/src/commands/clan/status.ts
+++ b/packages/oaf/src/commands/clan/status.ts
@@ -11,7 +11,7 @@ import { discordClient } from "../../clients/discord.js";
 import { assertNotRollover, kolClient } from "../../clients/kol.js";
 import { config } from "../../config.js";
 import { pluralize } from "../../utils.js";
-import { DREAD_CLANS } from "./_clans.js";
+import { DUNGEON_RUNNING_CLANS } from "./_clans.js";
 
 const dungeon = new DreadsylvaniaDungeon(kolClient);
 
@@ -22,7 +22,7 @@ async function constructDreadStatusMessage(): Promise<{
   const pingableClans: string[] = [];
 
   const messages = await Promise.all(
-    DREAD_CLANS.map(async (clan) => {
+    DUNGEON_RUNNING_CLANS.map(async (clan) => {
       const raid = await dungeon.getRaid(clan.id);
       const overview = raid.getOverview();
 

--- a/packages/oaf/src/commands/clan/whitelist.ts
+++ b/packages/oaf/src/commands/clan/whitelist.ts
@@ -4,10 +4,10 @@ import {
   SlashCommandBuilder,
 } from "discord.js";
 
-import { assertNotRollover, kolClient } from "../../clients/kol.js";
+import { assertNotRollover, clan } from "../../clients/kol.js";
 import { config } from "../../config.js";
 import { findPlayer } from "../_player.js";
-import { ALL_CLANS } from "./_clans.js";
+import { DUNGEON_CLANS } from "./_clans.js";
 
 const PERMITTED_ROLE_IDS = config.WHITELIST_ROLE_IDS.split(",");
 
@@ -54,8 +54,8 @@ export async function execute(interaction: ChatInputCommandInteraction) {
     ));
   }
 
-  for (const clan of ALL_CLANS) {
-    await kolClient.addToWhitelist(player.playerId, clan.id);
+  for (const dungeonClan of DUNGEON_CLANS) {
+    await clan.addPlayerToWhitelist(player.playerId, dungeonClan.id);
   }
 
   await interaction.editReply({


### PR DESCRIPTION
## Summary

- Extracts `addToWhitelist` (renamed `addPlayerToWhitelist`) and `transferClanLeadership` (renamed `transferLeadership`) out of `Client` into a new `Clan` domain class
- Adds `getInfo` to fetch clan name, leader, and credo from `showclan.php`
- `transferLeadership` now returns a `Result` with specific failure reasons including blank response (insufficient admin rights)
- Updates `whitelist.ts` to use the new `Clan` domain via `clan` exported from `kol.ts`
- Renames `DREAD_CLANS`/`NON_DREAD_CLANS`/`ALL_CLANS` to `DUNGEON_RUNNING_CLANS`/`DUNGEON_ADMIN_CLANS`/`DUNGEON_CLANS`

## Test plan

- [ ] All existing tests pass
- [ ] `Clan.test.ts` covers `getInfo` success, `transferLeadership` success/no-rights/unknown