### PR TITLE
Update to data-of-loathing v4.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "convert-svg-to-png": "^0.7.1",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.6",
-    "data-of-loathing": "^4.0.0",
+    "data-of-loathing": "4.1.0",
     "date-fns": "^4.1.0",
     "discord.js": "^14.25.1",
     "entities": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "build": "vite build --config vite.oaf.config.ts && vite build --config vite.calendar.config.ts && vite build --config vite.tulips.config.ts",
     "test": "vitest",
     "coverage": "vitest run --coverage",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "typecheck": "tsc --noEmit"
   },
   "author": "",
   "license": "ISC",
@@ -31,7 +32,7 @@
     "convert-svg-to-png": "^0.7.1",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.6",
-    "data-of-loathing": "3.2",
+    "data-of-loathing": "^4.0.0",
     "date-fns": "^4.1.0",
     "discord.js": "^14.25.1",
     "entities": "^7.0.1",

--- a/src/clients/dataOfLoathing.test.ts
+++ b/src/clients/dataOfLoathing.test.ts
@@ -20,8 +20,6 @@ beforeAll(async () => {
 describe("Wiki link", () => {
   test("Hermit", () => {
     const link = dataOfLoathingClient.getWikiLink(hermit);
-    expect(link).toBe(
-      "https://wiki.kingdomofloathing.com/Hermit_%28monster%29",
-    );
+    expect(link).toBe("https://wiki.kingdomofloathing.com/Monster:1781");
   });
 });

--- a/src/clients/dataOfLoathing.ts
+++ b/src/clients/dataOfLoathing.ts
@@ -246,21 +246,9 @@ export class DataOfLoathingClient {
     return embed;
   }
 
-  getWikiName(thing: Thing) {
-    const modifiers = thing.getModifiers();
-    if (modifiers && "Wiki Name" in modifiers) {
-      const wikiName = modifiers["Wiki Name"];
-      if (typeof wikiName !== "string") return null;
-      return wikiName.slice(1, -1);
-    }
-    return thing.name.replace(/ /g, "_");
-  }
-
   @memoize({ tags: ["things"] })
   getWikiLink(thing: Thing) {
-    const wikiName = this.getWikiName(thing);
-    if (!wikiName) return null;
-    return toWikiLink(wikiName);
+    return toWikiLink(thing.wiki);
   }
 }
 

--- a/src/things/Effect.ts
+++ b/src/things/Effect.ts
@@ -25,7 +25,7 @@ export class Effect extends Thing<DolEffect> {
   constructor(effect: DolEffect) {
     super(effect, effect.image);
     this.hookah =
-      !getModifier(effect.modifiers?.modifiers ?? [], "Avatar") &&
+      !getModifier(effect, "Avatar") &&
       !effect.nohookah &&
       effect.quality !== EffectQuality.Bad;
   }

--- a/src/things/Effect.ts
+++ b/src/things/Effect.ts
@@ -1,4 +1,8 @@
-import { type Effect as DolEffect, EffectQuality } from "data-of-loathing";
+import {
+  type Effect as DolEffect,
+  EffectQuality,
+  getModifier,
+} from "data-of-loathing";
 import { bold } from "discord.js";
 
 import { kolClient } from "../clients/kol.js";
@@ -23,7 +27,7 @@ export class Effect extends Thing {
     super(effect.id, effect.name, effect.image);
     this.#effect = effect;
     this.hookah =
-      !("Avatar" in (effect.modifiers?.modifiers ?? {})) &&
+      !getModifier(effect.modifiers?.modifiers ?? [], "Avatar") &&
       !effect.nohookah &&
       effect.quality !== EffectQuality.Bad;
   }

--- a/src/things/Effect.ts
+++ b/src/things/Effect.ts
@@ -14,8 +14,7 @@ export type PizzaData = {
   options: number;
 };
 
-export class Effect extends Thing {
-  #effect: DolEffect;
+export class Effect extends Thing<DolEffect> {
   readonly hookah: boolean;
   pizza?: PizzaData;
 
@@ -24,8 +23,7 @@ export class Effect extends Thing {
   }
 
   constructor(effect: DolEffect) {
-    super(effect.id, effect.name, effect.image);
-    this.#effect = effect;
+    super(effect, effect.image);
     this.hookah =
       !getModifier(effect.modifiers?.modifiers ?? [], "Avatar") &&
       !effect.nohookah &&
@@ -43,10 +41,8 @@ export class Effect extends Thing {
 
   @memoize()
   async getDescription() {
-    if (!this.#effect.descid) return "This effect seems to have no description";
-    const { blueText } = await kolClient.getEffectDescription(
-      this.#effect.descid,
-    );
+    if (!this.dol.descid) return "This effect seems to have no description";
+    const { blueText } = await kolClient.getEffectDescription(this.dol.descid);
     return [
       bold("Effect"),
       `(Effect ${this.id})`,

--- a/src/things/Effect.ts
+++ b/src/things/Effect.ts
@@ -28,10 +28,6 @@ export class Effect extends Thing {
       effect.quality !== EffectQuality.Bad;
   }
 
-  getModifiers(): Record<string, string> {
-    return this.#effect.modifiers?.modifiers ?? {};
-  }
-
   describePizzaCompatibility() {
     if (!this.hookah) return "Ineligible for pizza, wishes, or hookahs.";
     if (!this.pizza) return "Pizza: Something is broken.";

--- a/src/things/Familiar.ts
+++ b/src/things/Familiar.ts
@@ -281,8 +281,7 @@ export const HARD_CODED_FAMILIARS: Map<string, string> = new Map([
   ["o.a.f.", "Is optimal.\nGenerally messes with you.\n"],
 ]);
 
-export class Familiar extends Thing {
-  #familiar: DolFamiliar;
+export class Familiar extends Thing<DolFamiliar> {
   hatchling: Item | undefined;
   familiarEquipment: Item | undefined;
 
@@ -291,8 +290,7 @@ export class Familiar extends Thing {
   }
 
   constructor(familiar: DolFamiliar) {
-    super(familiar.id, familiar.name, familiar.image);
-    this.#familiar = familiar;
+    super(familiar, familiar.image);
     this.hatchling = familiar.larva
       ? new Item(familiar.larva, true)
       : undefined;
@@ -306,7 +304,7 @@ export class Familiar extends Thing {
     if (hardcoded) return hardcoded;
 
     const classifications: string[] = [];
-    let categoriesUnassigned = [...this.#familiar.categories];
+    let categoriesUnassigned = [...this.dol.categories];
 
     for (const classification of FAMILIAR_CLASSIFCATIONS) {
       if (
@@ -354,13 +352,13 @@ export class Familiar extends Thing {
       bold("Familiar"),
       this.classify(),
       "",
-      `Attributes: ${this.#familiar.attributes?.toSorted().join(", ") ?? "None"}`,
+      `Attributes: ${this.dol.attributes?.toSorted().join(", ") ?? "None"}`,
       "",
     ];
 
-    if (this.#familiar.larva) {
+    if (this.dol.larva) {
       description.push(
-        `Hatchling: ${hyperlink(this.#familiar.larva.name ?? "unknown larva", toWikiLink(this.#familiar.larva.name || ""))}`,
+        `Hatchling: ${hyperlink(this.dol.larva.name ?? "unknown larva", toWikiLink(this.dol.larva.name || ""))}`,
       );
     }
 
@@ -376,9 +374,9 @@ export class Familiar extends Thing {
 
     description.push("");
 
-    if (this.#familiar.equipment) {
+    if (this.dol.equipment) {
       description.push(
-        `Equipment: ${hyperlink(this.#familiar.equipment.name, toWikiLink(this.#familiar.equipment.name))}`,
+        `Equipment: ${hyperlink(this.dol.equipment.name, toWikiLink(this.dol.equipment.name))}`,
       );
     }
 

--- a/src/things/Familiar.ts
+++ b/src/things/Familiar.ts
@@ -301,10 +301,6 @@ export class Familiar extends Thing {
       : undefined;
   }
 
-  getModifiers(): Record<string, string> {
-    return this.#familiar.modifiers?.modifiers ?? {};
-  }
-
   private classify(): string {
     const hardcoded = HARD_CODED_FAMILIARS.get(this.name.toLowerCase());
     if (hardcoded) return hardcoded;

--- a/src/things/Item.ts
+++ b/src/things/Item.ts
@@ -88,10 +88,6 @@ export class Item extends Thing {
     }
   }
 
-  getModifiers(): Record<string, string> {
-    return this.#item.modifiers?.modifiers ?? {};
-  }
-
   get descid() {
     return this.#item.descid;
   }

--- a/src/things/Item.ts
+++ b/src/things/Item.ts
@@ -48,9 +48,7 @@ const OTHER_USES = [
 ] as const;
 type OtherUse = (typeof OTHER_USES)[number];
 
-export class Item extends Thing {
-  #item: DolItem;
-
+export class Item extends Thing<DolItem> {
   container?: string;
   contents?: string;
   zapGroup: Item[];
@@ -63,8 +61,7 @@ export class Item extends Thing {
   }
 
   constructor(item: DolItem, shallow = false) {
-    super(item.id, item.name, item.image);
-    this.#item = item;
+    super(item, item.image);
 
     if (item.name in packages) {
       this.contents = packages[item.name as keyof typeof packages];
@@ -89,23 +86,23 @@ export class Item extends Thing {
   }
 
   get descid() {
-    return this.#item.descid;
+    return this.dol.descid;
   }
 
   get tradeable() {
-    return this.#item.tradeable;
+    return this.dol.tradeable;
   }
 
   get gift() {
-    return this.#item.gift;
+    return this.dol.gift;
   }
 
   get plural() {
-    return this.#item.plural || `${this.name}s`;
+    return this.dol.plural || `${this.name}s`;
   }
 
   get autosell() {
-    return this.#item.autosell ?? 0;
+    return this.dol.autosell ?? 0;
   }
 
   mapQuality(rawQuality: ConsumableQuality | null | undefined): string {
@@ -156,12 +153,12 @@ export class Item extends Thing {
   }
 
   getConsumableDescription() {
-    const consumableUse = this.#item.uses.find((u): u is ConsumableUse =>
+    const consumableUse = this.dol.uses.find((u): u is ConsumableUse =>
       CONSUMABLE_USES.includes(u as ConsumableUse),
     );
     if (!consumableUse) return null;
 
-    const consumable = this.#item.consumable;
+    const consumable = this.dol.consumable;
     if (!consumable) return null;
 
     const description = [];
@@ -209,12 +206,12 @@ export class Item extends Thing {
   }
 
   getEquipmentDescription() {
-    const equipmentUse = this.#item.uses.find((u): u is EquipmentUse =>
+    const equipmentUse = this.dol.uses.find((u): u is EquipmentUse =>
       EQUIPMENT_USES.includes(u as EquipmentUse),
     );
     if (!equipmentUse) return null;
 
-    const equipment = this.#item.equipment;
+    const equipment = this.dol.equipment;
     if (!equipment) return null;
 
     const description = [];
@@ -270,12 +267,12 @@ export class Item extends Thing {
   }
 
   getOtherDescription() {
-    const otherUse = this.#item.uses.find((u): u is OtherUse =>
+    const otherUse = this.dol.uses.find((u): u is OtherUse =>
       OTHER_USES.includes(u as OtherUse),
     );
     if (!otherUse) return null;
 
-    const alsoCombat = this.#item.uses.includes(ItemUse.Combat);
+    const alsoCombat = this.dol.uses.includes(ItemUse.Combat);
 
     const title = (() => {
       switch (otherUse) {
@@ -306,12 +303,12 @@ export class Item extends Thing {
 
   getShortDescription(): string {
     const itemRules: string[] = [];
-    if (this.#item.quest) itemRules.push("Quest Item");
-    if (this.#item.gift) itemRules.push("Gift Item");
+    if (this.dol.quest) itemRules.push("Quest Item");
+    if (this.dol.gift) itemRules.push("Gift Item");
 
     const tradeability: string[] = [];
-    if (!this.#item.tradeable) tradeability.push("traded");
-    if (!this.#item.discardable) tradeability.push("discarded");
+    if (!this.dol.tradeable) tradeability.push("traded");
+    if (!this.dol.discardable) tradeability.push("discarded");
     if (tradeability.length > 0)
       itemRules.push(`Cannot be ${tradeability.join(" or ")}.`);
 
@@ -339,7 +336,7 @@ export class Item extends Thing {
   }
 
   async getMallPrice() {
-    if (!this.#item.tradeable) return "";
+    if (!this.dol.tradeable) return "";
 
     const {
       mallPrice,
@@ -410,11 +407,11 @@ export class Item extends Thing {
 
     if (withAddl) description.push(this._addlDescription);
 
-    const { blueText } = await kolClient.getItemDescription(this.#item.descid!);
+    const { blueText } = await kolClient.getItemDescription(this.dol.descid!);
     if (blueText) description.push(blueText);
 
-    if (this.#item.discardable && (this.#item.autosell ?? 0) > 0) {
-      description.push(`Autosell value: ${this.#item.autosell} Meat.`);
+    if (this.dol.discardable && (this.dol.autosell ?? 0) > 0) {
+      description.push(`Autosell value: ${this.dol.autosell} Meat.`);
     }
 
     const price = await this.getMallPrice();

--- a/src/things/Monster.test.ts
+++ b/src/things/Monster.test.ts
@@ -44,10 +44,10 @@ describe("Monster description", () => {
         "",
         "Drops:",
         "40 (±8) meat",
-        "2x [rat whisker](https://wiki.kingdomofloathing.com/rat_whisker) (100%)",
-        "2x [rat whisker](https://wiki.kingdomofloathing.com/rat_whisker) (Sometimes)",
-        "3x [rat appendix](https://wiki.kingdomofloathing.com/rat_appendix) (20%)",
-        "[tangle of rat tails](https://wiki.kingdomofloathing.com/tangle_of_rat_tails) (100%)",
+        "2x [rat whisker](https://wiki.kingdomofloathing.com/Item:197) (100%)",
+        "2x [rat whisker](https://wiki.kingdomofloathing.com/Item:197) (Sometimes)",
+        "3x [rat appendix](https://wiki.kingdomofloathing.com/Item:198) (20%)",
+        "[tangle of rat tails](https://wiki.kingdomofloathing.com/Item:4736) (100%)",
       ].join("\n"),
     );
   });
@@ -63,8 +63,8 @@ describe("Monster description", () => {
         "Always loses initiative.",
         "",
         "Drops:",
-        "[turtle voicebox](https://wiki.kingdomofloathing.com/turtle_voicebox) (15%)",
-        "[fake washboard](https://wiki.kingdomofloathing.com/fake_washboard) (0.1%, unaffected by item drop modifiers)",
+        "[turtle voicebox](https://wiki.kingdomofloathing.com/Item:8230) (15%)",
+        "[fake washboard](https://wiki.kingdomofloathing.com/Item:8231) (0.1%, unaffected by item drop modifiers)",
       ].join("\n"),
     );
   });
@@ -95,13 +95,13 @@ describe("Monster description", () => {
         "Can't be copied.",
         "",
         "Drops:",
-        "[Thunkula's drinking cap](https://wiki.kingdomofloathing.com/Thunkula's_drinking_cap) (100%, conditional)",
-        "[Drunkula's cape](https://wiki.kingdomofloathing.com/Drunkula's_cape) (100%, conditional)",
-        "[Drunkula's silky pants](https://wiki.kingdomofloathing.com/Drunkula's_silky_pants) (100%, conditional)",
-        "[Drunkula's ring of haze](https://wiki.kingdomofloathing.com/Drunkula's_ring_of_haze) (100%, conditional)",
-        "[Drunkula's wineglass](https://wiki.kingdomofloathing.com/Drunkula's_wineglass) (100%, conditional)",
-        "[Drunkula's bell](https://wiki.kingdomofloathing.com/Drunkula's_bell) (100%, conditional)",
-        "[skull capacitor](https://wiki.kingdomofloathing.com/skull_capacitor) (100%)",
+        "[Thunkula's drinking cap](https://wiki.kingdomofloathing.com/Item:6469) (100%, conditional)",
+        "[Drunkula's cape](https://wiki.kingdomofloathing.com/Item:6470) (100%, conditional)",
+        "[Drunkula's silky pants](https://wiki.kingdomofloathing.com/Item:6471) (100%, conditional)",
+        "[Drunkula's ring of haze](https://wiki.kingdomofloathing.com/Item:6473) (100%, conditional)",
+        "[Drunkula's wineglass](https://wiki.kingdomofloathing.com/Item:6474) (100%, conditional)",
+        "[Drunkula's bell](https://wiki.kingdomofloathing.com/Item:6472) (100%, conditional)",
+        "[skull capacitor](https://wiki.kingdomofloathing.com/Item:6512) (100%)",
       ].join("\n"),
     );
   });
@@ -116,8 +116,8 @@ describe("Monster description", () => {
         "",
         "Drops:",
         "15 (±3) meat",
-        "[bar skin](https://wiki.kingdomofloathing.com/bar_skin) (35%)",
-        "[baritone accordion](https://wiki.kingdomofloathing.com/baritone_accordion) (Stealable accordion)",
+        "[bar skin](https://wiki.kingdomofloathing.com/Item:70) (35%)",
+        "[baritone accordion](https://wiki.kingdomofloathing.com/Item:6811) (Stealable accordion)",
       ].join("\n"),
     );
   });

--- a/src/things/Monster.ts
+++ b/src/things/Monster.ts
@@ -9,28 +9,21 @@ import { inlineExpression } from "../discordUtils.js";
 import { memoize } from "../utils/memoize.js";
 import { Thing } from "./Thing.js";
 
-export class Monster extends Thing {
-  #monster: DolMonster;
-
+export class Monster extends Thing<DolMonster> {
   static is(thing?: Thing | null): thing is Monster {
     return !!thing && thing instanceof Monster;
   }
 
   constructor(monster: DolMonster) {
-    super(
-      monster.id,
-      monster.name,
-      monster.image.filter((i) => i !== null)[0] || "nopic.gif",
-    );
-    this.#monster = monster;
+    super(monster, monster.image.filter((i) => i !== null)[0] || "nopic.gif");
   }
 
   get copyable() {
-    return !this.#monster.nocopy;
+    return !this.dol.nocopy;
   }
 
   getPhylumEmoji() {
-    switch (this.#monster.phylum?.toLowerCase()) {
+    switch (this.dol.phylum?.toLowerCase()) {
       case "beast":
         return "🐺";
       case "bug":
@@ -80,7 +73,7 @@ export class Monster extends Thing {
   }
 
   getElementEmoji() {
-    switch (this.#monster.element?.toLowerCase()) {
+    switch (this.dol.element?.toLowerCase()) {
       case "hot":
         return "🔥";
       case "cold":
@@ -97,7 +90,7 @@ export class Monster extends Thing {
 
   getModifiers(): Record<string, string> {
     const mods: Record<string, string> = {};
-    if (this.#monster.wiki) mods["Wiki Name"] = `"${this.#monster.wiki}"`;
+    if (this.dol.wiki) mods["Wiki Name"] = `"${this.dol.wiki}"`;
     return mods;
   }
 
@@ -107,8 +100,8 @@ export class Monster extends Thing {
   }
 
   private getDropsDescription() {
-    const meat = this.#monster.meat;
-    const drops = this.#monster.drops.getItems();
+    const meat = this.dol.meat;
+    const drops = this.dol.drops.getItems();
 
     if (!drops.length && !meat) return null;
 
@@ -162,10 +155,10 @@ export class Monster extends Thing {
   async getDescription(): Promise<string> {
     const description = [bold("Monster"), `(Monster ${this.id})`];
 
-    const atk = this.#monster.attack;
-    const def = this.#monster.defence;
-    const hp = this.#monster.hp;
-    const scale = this.#monster.scaling;
+    const atk = this.dol.attack;
+    const def = this.dol.defence;
+    const hp = this.dol.hp;
+    const scale = this.dol.scaling;
 
     if (atk && atk !== "0" && def && def !== "0" && hp && hp !== "0") {
       description.push(
@@ -186,10 +179,10 @@ export class Monster extends Thing {
       }
 
       const scaleBounds: string[] = [];
-      if (this.#monster.scalingFloor !== "0")
-        scaleBounds.push(`min ${this.#monster.scalingFloor}`);
-      if (this.#monster.scalingCap !== "0")
-        scaleBounds.push(`max ${this.#monster.scalingCap}`);
+      if (this.dol.scalingFloor !== "0")
+        scaleBounds.push(`min ${this.dol.scalingFloor}`);
+      if (this.dol.scalingCap !== "0")
+        scaleBounds.push(`max ${this.dol.scalingCap}`);
       if (scaleBounds.length > 0)
         scaleDetails.push(`(${scaleBounds.join(", ")})`);
 
@@ -200,22 +193,20 @@ export class Monster extends Thing {
       description.push("Scales unusually.");
     }
 
-    if (this.#monster.phylum)
+    if (this.dol.phylum)
+      description.push(`Phylum: ${this.dol.phylum} ${this.getPhylumEmoji()}`);
+    if (this.dol.element)
       description.push(
-        `Phylum: ${this.#monster.phylum} ${this.getPhylumEmoji()}`,
+        `Element: ${this.dol.element.toLowerCase()} ${this.getElementEmoji()}`,
       );
-    if (this.#monster.element)
-      description.push(
-        `Element: ${this.#monster.element.toLowerCase()} ${this.getElementEmoji()}`,
-      );
-    if (this.#monster.initiative === "10000")
+    if (this.dol.initiative === "10000")
       description.push("Always wins initiative.");
-    if (this.#monster.initiative === "-10000")
+    if (this.dol.initiative === "-10000")
       description.push("Always loses initiative.");
-    if (this.#monster.free) description.push("Doesn't cost a turn to fight.");
-    if (this.#monster.nocopy) description.push("Can't be copied.");
-    if (this.#monster.boss) description.push("Instakill immune.");
-    if (this.#monster.ultrarare) description.push("Ultra-rare encounter.");
+    if (this.dol.free) description.push("Doesn't cost a turn to fight.");
+    if (this.dol.nocopy) description.push("Can't be copied.");
+    if (this.dol.boss) description.push("Instakill immune.");
+    if (this.dol.ultrarare) description.push("Ultra-rare encounter.");
 
     const drops = this.getDropsDescription();
     if (drops) description.push("", drops);

--- a/src/things/Monster.ts
+++ b/src/things/Monster.ts
@@ -88,12 +88,6 @@ export class Monster extends Thing<DolMonster> {
     return "⁉️";
   }
 
-  getModifiers(): Record<string, string> {
-    const mods: Record<string, string> = {};
-    if (this.dol.wiki) mods["Wiki Name"] = `"${this.dol.wiki}"`;
-    return mods;
-  }
-
   getImagePath() {
     if (this.imageUrl.includes("/")) return `/${this.imageUrl}`;
     return `/adventureimages/${this.imageUrl}`;

--- a/src/things/Monster.ts
+++ b/src/things/Monster.ts
@@ -125,7 +125,7 @@ export class Monster extends Thing<DolMonster> {
           dropDetails.push("unaffected by item drop modifiers");
       }
 
-      const dropDescription = `${hyperlink(itemName, toWikiLink(itemName))} (${dropDetails.join(", ")})`;
+      const dropDescription = `${hyperlink(itemName, toWikiLink(`Item:${drop.item.id}`))} (${dropDetails.join(", ")})`;
       dropDescriptions.set(
         dropDescription,
         (dropDescriptions.get(dropDescription) || 0) + 1,

--- a/src/things/Skill.ts
+++ b/src/things/Skill.ts
@@ -35,10 +35,6 @@ export class Skill extends Thing {
     return Math.floor(this.#skill.id / 1000);
   }
 
-  getModifiers(): Record<string, string> {
-    return this.#skill.modifiers?.modifiers ?? {};
-  }
-
   @memoize()
   async getDescription(): Promise<string> {
     const description: string[] = [];

--- a/src/things/Skill.ts
+++ b/src/things/Skill.ts
@@ -19,35 +19,32 @@ const TAG_LABELS: Record<SkillTag, string> = {
   [SkillTag.Walk]: "Walk",
 };
 
-export class Skill extends Thing {
-  #skill: DolSkill;
-
+export class Skill extends Thing<DolSkill> {
   static is(thing?: Thing | null): thing is Skill {
     return !!thing && thing instanceof Skill;
   }
 
   constructor(skill: DolSkill) {
-    super(skill.id, skill.name, skill.image);
-    this.#skill = skill;
+    super(skill, skill.image);
   }
 
   block(): number {
-    return Math.floor(this.#skill.id / 1000);
+    return Math.floor(this.dol.id / 1000);
   }
 
   @memoize()
   async getDescription(): Promise<string> {
     const description: string[] = [];
 
-    const tags = this.#skill.tags
+    const tags = this.dol.tags
       .map((tag) => TAG_LABELS[tag])
       .filter(Boolean)
       .join(", ");
     description.push(bold(tags));
 
     description.push(`(Skill ${this.id})`);
-    if (!this.#skill.tags.includes(SkillTag.Passive)) {
-      description.push(`Cost: ${this.#skill.mpCost}mp`);
+    if (!this.dol.tags.includes(SkillTag.Passive)) {
+      description.push(`Cost: ${this.dol.mpCost}mp`);
     }
 
     const { blueText } = await kolClient.getSkillDescription(this.id);

--- a/src/things/Thing.ts
+++ b/src/things/Thing.ts
@@ -2,17 +2,25 @@ import { EmbedBuilder } from "discord.js";
 import { decodeHTML } from "entities";
 import { resolveKoLImage } from "kol.js";
 
-export class Thing {
-  readonly id: number;
-  readonly name: string;
+export abstract class Thing<
+  T extends { id: number; name: string } = { id: number; name: string },
+> {
+  protected readonly dol: T;
   readonly imageUrl: string;
   readonly wiki: string;
 
-  constructor(id: number, name: string, image: string) {
-    this.id = id;
-    this.name = decodeHTML(name);
+  constructor(dol: T, image: string) {
+    this.dol = dol;
     this.imageUrl = image;
-    this.wiki = `${this.constructor.name.replace(/^_*/, "")}:${this.id}`;
+    this.wiki = `${this.constructor.name.replace(/^_*/, "")}:${dol.id}`;
+  }
+
+  get id() {
+    return this.dol.id;
+  }
+
+  get name() {
+    return decodeHTML(this.dol.name);
   }
 
   hashcode() {

--- a/src/things/Thing.ts
+++ b/src/things/Thing.ts
@@ -6,15 +6,17 @@ export class Thing {
   readonly id: number;
   readonly name: string;
   readonly imageUrl: string;
+  readonly wiki: string;
 
   constructor(id: number, name: string, image: string) {
     this.id = id;
     this.name = decodeHTML(name);
     this.imageUrl = image;
+    this.wiki = `${this.constructor.name.replace(/^_*/, "")}:${this.id}`;
   }
 
   hashcode() {
-    return `${this.constructor.name.replace(/^_*/, "")}:${this.id}`;
+    return this.wiki;
   }
 
   getDescription(): Promise<string> {
@@ -34,9 +36,5 @@ export class Thing {
     return this.addImageToEmbed(embed).setDescription(
       await this.getDescription(),
     );
-  }
-
-  getModifiers(): Record<string, string> | null {
-    throw new Error("Implement me");
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -881,25 +881,25 @@ __metadata:
   linkType: hard
 
 "@mikro-orm/core@npm:^7.0.14":
-  version: 7.0.16
-  resolution: "@mikro-orm/core@npm:7.0.16"
+  version: 7.0.17
+  resolution: "@mikro-orm/core@npm:7.0.17"
   peerDependencies:
     dataloader: 2.2.3
   peerDependenciesMeta:
     dataloader:
       optional: true
-  checksum: 10c0/5e47139fc3c80fc24157f6d4957f0eb6fc120252dee2d3b9803d77ba25bfe268088c401193d3c7d5060b3d10b809760f713a7af992717a9ee9124b913e3bef7d
+  checksum: 10c0/19147ac18250bec358100e347fb56c77ed2e0984ebf0f78b9b4954d88bde7bca761a0883986324de84cd87a88b6803d49c52ed3e5fc6c794ef98b935b3dd3cab
   languageName: node
   linkType: hard
 
 "@mikro-orm/sql@npm:^7.0.14":
-  version: 7.0.16
-  resolution: "@mikro-orm/sql@npm:7.0.16"
+  version: 7.0.17
+  resolution: "@mikro-orm/sql@npm:7.0.17"
   dependencies:
-    kysely: "npm:0.29.0"
+    kysely: "npm:0.29.2"
   peerDependencies:
-    "@mikro-orm/core": 7.0.16
-  checksum: 10c0/91031a1330c5ca0e6695833e3e20d4c6f7927f428f4354380d5fefaf3ecd2ad8ae503a8410397baae03fac5bdf0bac9b191eba18cb437521afa9a99219fa4d9b
+    "@mikro-orm/core": 7.0.17
+  checksum: 10c0/501a517e2bd5c02d6e4c8907c6053b290a97ad61e45aea9d781402c812e07cb70921e8f21ba41a508c32e40c3c4b7772e3a25cacc03dea8981a1764822003fca
   languageName: node
   linkType: hard
 
@@ -3145,9 +3145,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"data-of-loathing@npm:3.2":
-  version: 3.2.2
-  resolution: "data-of-loathing@npm:3.2.2"
+"data-of-loathing@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "data-of-loathing@npm:4.0.0"
   dependencies:
     "@mikro-orm/core": "npm:^7.0.14"
     "@mikro-orm/sql": "npm:^7.0.14"
@@ -3162,7 +3162,7 @@ __metadata:
       optional: true
     vite-plugin-node-polyfills:
       optional: true
-  checksum: 10c0/c2238b96ef4be0e8c3384ca205ba80cb9b54e2c8e92d09c6d85f5fba0de316bfff642e899fbac874869ff32f50cac0b74bccbfeaec0d542f740f4c16384c832e
+  checksum: 10c0/1ad3f34aeaf1b776cb0a983e9fe6bea68df3d1e6c922ba76a7d9c445ceabbc16775c4adaae3b73c49b895e604fb1d4334b82c1f044b9b151e3ff7a0205fc4958
   languageName: node
   linkType: hard
 
@@ -4807,10 +4807,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"kysely@npm:0.29.0":
-  version: 0.29.0
-  resolution: "kysely@npm:0.29.0"
-  checksum: 10c0/26765fbe6c80d75e7a2a2701b0f9a2a6e753a6258258a5c5bd3bccc395b9158688df271d9253d71a90c58032e9c31fc717124b5b96729a9c226af119d29cc1a5
+"kysely@npm:0.29.2":
+  version: 0.29.2
+  resolution: "kysely@npm:0.29.2"
+  checksum: 10c0/ed2c4b438fc685def6ce15f1cc8a35192903fa0dd74ee84d959cbd61b3bc8c13e24618aeaf0495298f99f84024181e91d4506b74bec38b7ec325a733dff01dad
   languageName: node
   linkType: hard
 
@@ -5428,7 +5428,7 @@ __metadata:
     convert-svg-to-png: "npm:^0.7.1"
     cookie-parser: "npm:^1.4.7"
     cors: "npm:^2.8.6"
-    data-of-loathing: "npm:3.2"
+    data-of-loathing: "npm:^4.0.0"
     date-fns: "npm:^4.1.0"
     discord.js: "npm:^14.25.1"
     entities: "npm:^7.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3145,9 +3145,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"data-of-loathing@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "data-of-loathing@npm:4.0.0"
+"data-of-loathing@npm:4.1.0":
+  version: 4.1.0
+  resolution: "data-of-loathing@npm:4.1.0"
   dependencies:
     "@mikro-orm/core": "npm:^7.0.14"
     "@mikro-orm/sql": "npm:^7.0.14"
@@ -3162,7 +3162,7 @@ __metadata:
       optional: true
     vite-plugin-node-polyfills:
       optional: true
-  checksum: 10c0/1ad3f34aeaf1b776cb0a983e9fe6bea68df3d1e6c922ba76a7d9c445ceabbc16775c4adaae3b73c49b895e604fb1d4334b82c1f044b9b151e3ff7a0205fc4958
+  checksum: 10c0/a57315c26b1bf9e41c1ba3962d781425170473d71bef4968355a7bbbb546856cdac4453933e6a626bb2a67d855659fa34182ee61ce2ead71231ac522c5501d7f
   languageName: node
   linkType: hard
 
@@ -5428,7 +5428,7 @@ __metadata:
     convert-svg-to-png: "npm:^0.7.1"
     cookie-parser: "npm:^1.4.7"
     cors: "npm:^2.8.6"
-    data-of-loathing: "npm:^4.0.0"
+    data-of-loathing: "npm:4.1.0"
     date-fns: "npm:^4.1.0"
     discord.js: "npm:^14.25.1"
     entities: "npm:^7.0.1"


### PR DESCRIPTION
## Summary

- Updates data-of-loathing from v3.x to v4.1.0
- Restructures the `Thing` hierarchy to sit explicitly on top of d-o-l: `Thing` is now a generic abstract class `Thing<T>`, each subclass extends `Thing<DolFoo>` and accesses the d-o-l entity via `this.dol` rather than a private field — eliminating duplicate storage of `id`/`name` and the five private `#item`/`#effect`/`#monster`/`#skill`/`#familiar` fields
- Updates `getModifier` call signature for the new API
- Removes unused `getModifiers()` method from `Monster`

## Test plan

- [ ] `yarn typecheck` passes
- [ ] Bot starts and responds to item/effect/monster/skill/familiar lookups