### PR TITLE
Fix Mr. Store IotM tracking failing on partial-index upsert

### DIFF
--- a/.github/workflows/oaf.yml
+++ b/.github/workflows/oaf.yml
@@ -4,6 +4,18 @@ on: push
 jobs:
   test:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -15,5 +27,7 @@ jobs:
         run: yarn install --immutable
       - name: Run tests
         run: yarn test
+        env:
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
       - name: Run type check
         run: yarn tsc

--- a/src/clients/database.iotm.test.ts
+++ b/src/clients/database.iotm.test.ts
@@ -1,0 +1,124 @@
+import { sql } from "kysely";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from "vitest";
+
+// This is a real-database integration test for upsertIotmByName. It only runs when
+// a DATABASE_URL is provided (skipped otherwise, e.g. local `yarn test` without a
+// DB); CI supplies a throwaway Postgres service. We inject the URL into `config`
+// because src/config.ts deliberately returns `{}` under Vitest.
+vi.mock("../config.js", () => ({
+  config: { DATABASE_URL: process.env.DATABASE_URL },
+}));
+
+const { db, upsertIotmByName, setIotmRemovedFromStore } =
+  await import("./database.js");
+
+const NAME = "__test_iotm_upsert__";
+const MONTH = new Date("2099-01-01");
+
+const describeIfDb = process.env.DATABASE_URL ? describe : describe.skip;
+
+describeIfDb("upsertIotmByName (integration)", () => {
+  beforeAll(async () => {
+    // Mirror the real schema so ON CONFLICT hits the same *partial* unique index.
+    await sql`
+      CREATE TABLE IF NOT EXISTS "Iotm" (
+        "id" SERIAL PRIMARY KEY,
+        "itemName" TEXT,
+        "itemDescid" INTEGER,
+        "itemImage" TEXT,
+        "month" DATE NOT NULL,
+        "mraCost" INTEGER NOT NULL DEFAULT 1,
+        "subscriberItem" BOOLEAN NOT NULL DEFAULT false,
+        "addedToStore" TIMESTAMPTZ,
+        "removedFromStore" TIMESTAMPTZ,
+        "distributedToSubscribers" TIMESTAMPTZ
+      )
+    `.execute(db);
+    await sql`
+      CREATE UNIQUE INDEX IF NOT EXISTS "Iotm_itemName_key"
+      ON "Iotm" ("itemName") WHERE "itemName" IS NOT NULL
+    `.execute(db);
+  });
+
+  beforeEach(async () => {
+    await db.deleteFrom("Iotm").where("itemName", "=", NAME).execute();
+  });
+
+  afterAll(async () => {
+    await db.deleteFrom("Iotm").where("itemName", "=", NAME).execute();
+    await db.destroy();
+  });
+
+  // Regression: the unique index on itemName is partial (WHERE "itemName" IS NOT
+  // NULL). Without repeating that predicate in the ON CONFLICT target, Postgres
+  // raises 42P10 on every upsert, which silently aborted checkStore.
+  test("a conflicting upsert does not throw", async () => {
+    await upsertIotmByName({
+      itemName: NAME,
+      month: MONTH,
+      subscriberItem: false,
+      addedToStore: new Date("2099-01-01T03:30:00Z"),
+    });
+
+    await expect(
+      upsertIotmByName({
+        itemName: NAME,
+        month: MONTH,
+        subscriberItem: false,
+        addedToStore: new Date("2099-02-01T03:30:00Z"),
+      }),
+    ).resolves.not.toThrow();
+  });
+
+  // Regression: addedToStore must reflect the true entry, not be bumped on every
+  // rollover the item stays in the store.
+  test("addedToStore is preserved while the item stays in store, and reset on re-entry", async () => {
+    const entry = new Date("2099-01-01T03:30:00Z");
+    await upsertIotmByName({
+      itemName: NAME,
+      month: MONTH,
+      subscriberItem: false,
+      addedToStore: entry,
+    });
+
+    // Still in store on a later rollover — entry must be preserved.
+    await upsertIotmByName({
+      itemName: NAME,
+      month: MONTH,
+      subscriberItem: false,
+      addedToStore: new Date("2099-02-01T03:30:00Z"),
+    });
+
+    let row = await db
+      .selectFrom("Iotm")
+      .select("addedToStore")
+      .where("itemName", "=", NAME)
+      .executeTakeFirstOrThrow();
+    expect(row.addedToStore?.toISOString()).toBe(entry.toISOString());
+
+    // Item leaves, then re-enters later — entry should now update.
+    await setIotmRemovedFromStore(NAME, new Date("2099-02-15T03:30:00Z"));
+    const reentry = new Date("2099-03-01T03:30:00Z");
+    await upsertIotmByName({
+      itemName: NAME,
+      month: MONTH,
+      subscriberItem: false,
+      addedToStore: reentry,
+    });
+
+    row = await db
+      .selectFrom("Iotm")
+      .select("addedToStore")
+      .where("itemName", "=", NAME)
+      .executeTakeFirstOrThrow();
+    expect(row.addedToStore?.toISOString()).toBe(reentry.toISOString());
+  });
+});

--- a/src/clients/database.iotm.test.ts
+++ b/src/clients/database.iotm.test.ts
@@ -89,7 +89,7 @@ describeIfDb("upsertIotmByName (integration)", () => {
       addedToStore: entry,
     });
 
-    // Still in store on a later rollover — entry must be preserved.
+    // Still in store on a later rollover - entry must be preserved.
     await upsertIotmByName({
       itemName: NAME,
       month: MONTH,
@@ -104,7 +104,7 @@ describeIfDb("upsertIotmByName (integration)", () => {
       .executeTakeFirstOrThrow();
     expect(row.addedToStore?.toISOString()).toBe(entry.toISOString());
 
-    // Item leaves, then re-enters later — entry should now update.
+    // Item leaves, then re-enters later - entry should now update.
     await setIotmRemovedFromStore(NAME, new Date("2099-02-15T03:30:00Z"));
     const reentry = new Date("2099-03-01T03:30:00Z");
     await upsertIotmByName({

--- a/src/clients/database.ts
+++ b/src/clients/database.ts
@@ -24,7 +24,7 @@ const pool = new pg.Pool({
   connectionString: getConnectionString(),
 });
 
-// Handle idle client errors gracefully — the pool replaces dead connections automatically
+// Handle idle client errors gracefully - the pool replaces dead connections automatically
 pool.on("error", (err) => {
   console.error("Database pool error (connection will be replaced):", err);
 });
@@ -1071,7 +1071,7 @@ export async function upsertIotmByName(data: {
           itemImage: data.itemImage ?? null,
           ...(data.mraCost !== undefined && { mraCost: data.mraCost }),
           // Preserve the original entry; only (re)set addedToStore when the item
-          // is genuinely (re-)entering — previously removed, or never recorded.
+          // is genuinely (re-)entering - previously removed, or never recorded.
           addedToStore: sql`CASE WHEN ${eb.ref("Iotm.removedFromStore")} IS NOT NULL OR ${eb.ref("Iotm.addedToStore")} IS NULL THEN ${eb.ref("excluded.addedToStore")} ELSE ${eb.ref("Iotm.addedToStore")} END`,
         })),
     )

--- a/src/clients/database.ts
+++ b/src/clients/database.ts
@@ -1061,12 +1061,19 @@ export async function upsertIotmByName(data: {
       addedToStore: data.addedToStore ?? null,
     })
     .onConflict((oc) =>
-      oc.column("itemName").doUpdateSet({
-        itemDescid: data.itemDescid ?? null,
-        itemImage: data.itemImage ?? null,
-        ...(data.mraCost !== undefined && { mraCost: data.mraCost }),
-        addedToStore: data.addedToStore ?? null,
-      }),
+      // The unique index on itemName is partial (WHERE "itemName" IS NOT NULL),
+      // so the conflict target must repeat the predicate for Postgres to infer it.
+      oc
+        .column("itemName")
+        .where("itemName", "is not", null)
+        .doUpdateSet((eb) => ({
+          itemDescid: data.itemDescid ?? null,
+          itemImage: data.itemImage ?? null,
+          ...(data.mraCost !== undefined && { mraCost: data.mraCost }),
+          // Preserve the original entry; only (re)set addedToStore when the item
+          // is genuinely (re-)entering — previously removed, or never recorded.
+          addedToStore: sql`CASE WHEN ${eb.ref("Iotm.removedFromStore")} IS NOT NULL OR ${eb.ref("Iotm.addedToStore")} IS NULL THEN ${eb.ref("excluded.addedToStore")} ELSE ${eb.ref("Iotm.addedToStore")} END`,
+        })),
     )
     .execute();
 }

--- a/src/commands/kol/claim.ts
+++ b/src/commands/kol/claim.ts
@@ -195,7 +195,7 @@ async function onMessage(message: Message) {
 
   const deleteStatus = deleted
     ? "I've deleted it"
-    : `I tried to delete it but couldn't — you should ${hyperlink("delete it yourself", message.url)}`;
+    : `I tried to delete it but couldn't - you should ${hyperlink("delete it yourself", message.url)}`;
 
   await dm.send(
     `Looks like you accidentally sent your claim token as a plain message. ${deleteStatus}. I'll do my best with what you've given me.`,

--- a/src/commands/kol/crowdsource.test.ts
+++ b/src/commands/kol/crowdsource.test.ts
@@ -227,7 +227,7 @@ describe("handleSubmission", () => {
   });
 
   test("uses provided time for gameday, not current time", async () => {
-    // Before rollover — should resolve to the previous gameday
+    // Before rollover - should resolve to the previous gameday
     const whisperTime = new Date("2026-03-22T03:00:00Z");
     gameDayFromRealDate.mockImplementation((d: Date) =>
       d.getTime() === whisperTime.getTime() ? 99 : 100,

--- a/src/commands/kol/mrstore.test.ts
+++ b/src/commands/kol/mrstore.test.ts
@@ -1,0 +1,129 @@
+import type { MrStoreItem } from "kol.js/domains/MrStore";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const {
+  upsertIotmByName,
+  clearIotmRemovedFromStore,
+  setIotmRemovedFromStore,
+  getIotmsInStore,
+} = vi.hoisted(() => ({
+  upsertIotmByName: vi.fn(),
+  clearIotmRemovedFromStore: vi.fn(),
+  setIotmRemovedFromStore: vi.fn(),
+  getIotmsInStore: vi.fn(),
+}));
+
+const { alert } = vi.hoisted(() => ({ alert: vi.fn() }));
+
+const { getCurrentItems } = vi.hoisted(() => ({ getCurrentItems: vi.fn() }));
+
+vi.mock("../../clients/database.js", () => ({
+  upsertIotmByName,
+  clearIotmRemovedFromStore,
+  setIotmRemovedFromStore,
+  getIotmsInStore,
+}));
+
+vi.mock("../../clients/discord.js", () => ({
+  discordClient: { alert, on: vi.fn() },
+}));
+
+vi.mock("../../clients/kol.js", () => ({
+  kolClient: { on: vi.fn() },
+}));
+
+vi.mock("../../server/apps/oaf/routes/subs.js", () => ({
+  determineIotmMonth: () => new Date("2026-06-01T00:00:00Z"),
+}));
+
+vi.mock("kol.js", () => ({
+  LoathingDate: {
+    getRollover: () => new Date("2026-06-10T03:30:00Z"),
+    getNextRollover: () => new Date("2026-06-11T03:30:00Z"),
+  },
+}));
+
+vi.mock("kol.js/domains/MrStore", () => ({
+  MrStore: class {
+    getCurrentItems = getCurrentItems;
+  },
+  MrStoreUrgency: { None: 0, Soon: 1, Today: 2 } as const,
+}));
+
+const { checkStore } = await import("./mrstore.js");
+
+function item(name: string, urgency = 0): MrStoreItem {
+  return {
+    name,
+    descid: 1,
+    image: `${name}.gif`,
+    cost: 1,
+    currency: "mr_accessory",
+    category: "Stuff",
+    urgency: urgency as MrStoreItem["urgency"],
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getIotmsInStore.mockResolvedValue([]);
+});
+
+describe("checkStore", () => {
+  // Regression: a single item that fails to upsert must NOT abort the whole run.
+  // Previously checkStore had no per-item try/catch, so one throw skipped the
+  // removal-detection loop entirely — which is why a departed item (e.g. the May
+  // IotM "pasta wand loot box") was never marked as removed.
+  test("a failing item does not skip removal detection for other items", async () => {
+    getCurrentItems.mockResolvedValue([item("first"), item("second")]);
+    upsertIotmByName.mockImplementation(async ({ itemName }) => {
+      if (itemName === "first") throw new Error("boom");
+    });
+    // "departed" was tracked previously but is no longer in the store.
+    getIotmsInStore.mockResolvedValue([{ itemName: "departed" }]);
+
+    await checkStore();
+
+    // The bad item was reported but did not abort the run.
+    expect(alert).toHaveBeenCalledWith(
+      'checkStore: failed to process "first"',
+      undefined,
+      expect.any(Error),
+    );
+    // The loop continued to the next item.
+    expect(upsertIotmByName).toHaveBeenCalledWith(
+      expect.objectContaining({ itemName: "second" }),
+    );
+    // Crucially, the removal-detection loop still ran.
+    expect(setIotmRemovedFromStore).toHaveBeenCalledWith(
+      "departed",
+      new Date("2026-06-10T03:30:00Z"),
+    );
+  });
+
+  test("predicts removal for items leaving today", async () => {
+    getCurrentItems.mockResolvedValue([item("leaving", 2)]);
+    upsertIotmByName.mockResolvedValue(undefined);
+
+    await checkStore();
+
+    expect(setIotmRemovedFromStore).toHaveBeenCalledWith(
+      "leaving",
+      new Date("2026-06-11T03:30:00Z"),
+    );
+  });
+
+  // An empty fetch is untrustworthy (the API returns {} during rollover); it must
+  // not be interpreted as "every tracked item left the store".
+  test("an empty fetch is skipped without touching the database", async () => {
+    getCurrentItems.mockResolvedValue([]);
+
+    await checkStore();
+
+    expect(getIotmsInStore).not.toHaveBeenCalled();
+    expect(setIotmRemovedFromStore).not.toHaveBeenCalled();
+    expect(alert).toHaveBeenCalledWith(
+      "checkStore: store fetch was empty — skipping (possible rollover quirk)",
+    );
+  });
+});

--- a/src/commands/kol/mrstore.test.ts
+++ b/src/commands/kol/mrstore.test.ts
@@ -72,7 +72,7 @@ beforeEach(() => {
 describe("checkStore", () => {
   // Regression: a single item that fails to upsert must NOT abort the whole run.
   // Previously checkStore had no per-item try/catch, so one throw skipped the
-  // removal-detection loop entirely — which is why a departed item (e.g. the May
+  // removal-detection loop entirely - which is why a departed item (e.g. the May
   // IotM "pasta wand loot box") was never marked as removed.
   test("a failing item does not skip removal detection for other items", async () => {
     getCurrentItems.mockResolvedValue([item("first"), item("second")]);
@@ -123,7 +123,7 @@ describe("checkStore", () => {
     expect(getIotmsInStore).not.toHaveBeenCalled();
     expect(setIotmRemovedFromStore).not.toHaveBeenCalled();
     expect(alert).toHaveBeenCalledWith(
-      "checkStore: store fetch was empty — skipping (possible rollover quirk)",
+      "checkStore: store fetch was empty - skipping (possible rollover quirk)",
     );
   });
 });

--- a/src/commands/kol/mrstore.ts
+++ b/src/commands/kol/mrstore.ts
@@ -30,14 +30,14 @@ export async function checkStore() {
 
   try {
     void discordClient.alert(
-      `checkStore: fetched ${items.length} item(s) — ${items.map((i) => `${i.name} (urgency=${i.urgency})`).join(", ") || "none"}`,
+      `checkStore: fetched ${items.length} item(s) - ${items.map((i) => `${i.name} (urgency=${i.urgency})`).join(", ") || "none"}`,
     );
 
     // An empty fetch is treated as untrustworthy (the API returns {} during
-    // rollover) — skip rather than mark every tracked item as removed.
+    // rollover) - skip rather than mark every tracked item as removed.
     if (items.length === 0) {
       void discordClient.alert(
-        "checkStore: store fetch was empty — skipping (possible rollover quirk)",
+        "checkStore: store fetch was empty - skipping (possible rollover quirk)",
       );
       return;
     }

--- a/src/commands/kol/mrstore.ts
+++ b/src/commands/kol/mrstore.ts
@@ -15,7 +15,7 @@ const IOTM_CATEGORY_PATTERN = /^.+'s Item-of-the-Month$/;
 
 const mrStore = new MrStore(kolClient);
 
-async function checkStore() {
+export async function checkStore() {
   let items;
   try {
     items = await mrStore.getCurrentItems();
@@ -28,51 +28,79 @@ async function checkStore() {
     return;
   }
 
-  void discordClient.alert(
-    `checkStore: fetched ${items.length} item(s) — ${items.map((i) => `${i.name} (urgency=${i.urgency})`).join(", ") || "none"}`,
-  );
+  try {
+    void discordClient.alert(
+      `checkStore: fetched ${items.length} item(s) — ${items.map((i) => `${i.name} (urgency=${i.urgency})`).join(", ") || "none"}`,
+    );
 
-  if (items.length === 0) return;
-
-  const now = LoathingDate.getRollover();
-  const month = determineIotmMonth();
-
-  const currentNames = new Set<string>();
-
-  for (const item of items) {
-    currentNames.add(item.name);
-
-    const subscriberItem = IOTM_CATEGORY_PATTERN.test(item.category);
-
-    await upsertIotmByName({
-      itemName: item.name,
-      itemDescid: item.descid,
-      itemImage: item.image,
-      month,
-      mraCost: item.cost,
-      subscriberItem,
-      addedToStore: now,
-    });
-
-    // Always clear first so stale predictions are removed, then re-predict if still leaving today
-    await clearIotmRemovedFromStore(item.name);
-    if (item.urgency === MrStoreUrgency.Today) {
+    // An empty fetch is treated as untrustworthy (the API returns {} during
+    // rollover) — skip rather than mark every tracked item as removed.
+    if (items.length === 0) {
       void discordClient.alert(
-        `checkStore: predicting removal of "${item.name}" at next rollover`,
+        "checkStore: store fetch was empty — skipping (possible rollover quirk)",
       );
-      await setIotmRemovedFromStore(item.name, LoathingDate.getNextRollover());
+      return;
     }
-  }
 
-  // Mark any previously-tracked items no longer in the store as removed
-  const inStore = await getIotmsInStore();
-  for (const iotm of inStore) {
-    if (iotm.itemName && !currentNames.has(iotm.itemName)) {
-      void discordClient.alert(
-        `checkStore: marking "${iotm.itemName}" as removed from store`,
-      );
-      await setIotmRemovedFromStore(iotm.itemName, now);
+    const now = LoathingDate.getRollover();
+    const month = determineIotmMonth();
+
+    const currentNames = new Set<string>();
+
+    for (const item of items) {
+      currentNames.add(item.name);
+
+      // Isolate each item so one failure can't abort the whole run (and,
+      // crucially, can't skip the removal-detection loop below).
+      try {
+        const subscriberItem = IOTM_CATEGORY_PATTERN.test(item.category);
+
+        await upsertIotmByName({
+          itemName: item.name,
+          itemDescid: item.descid,
+          itemImage: item.image,
+          month,
+          mraCost: item.cost,
+          subscriberItem,
+          addedToStore: now,
+        });
+
+        // Always clear first so stale predictions are removed, then re-predict if still leaving today
+        await clearIotmRemovedFromStore(item.name);
+        if (item.urgency === MrStoreUrgency.Today) {
+          void discordClient.alert(
+            `checkStore: predicting removal of "${item.name}" at next rollover`,
+          );
+          await setIotmRemovedFromStore(
+            item.name,
+            LoathingDate.getNextRollover(),
+          );
+        }
+      } catch (error) {
+        void discordClient.alert(
+          `checkStore: failed to process "${item.name}"`,
+          undefined,
+          error instanceof Error ? error : undefined,
+        );
+      }
     }
+
+    // Mark any previously-tracked items no longer in the store as removed
+    const inStore = await getIotmsInStore();
+    for (const iotm of inStore) {
+      if (iotm.itemName && !currentNames.has(iotm.itemName)) {
+        void discordClient.alert(
+          `checkStore: marking "${iotm.itemName}" as removed from store`,
+        );
+        await setIotmRemovedFromStore(iotm.itemName, now);
+      }
+    }
+  } catch (error) {
+    void discordClient.alert(
+      "checkStore failed unexpectedly",
+      undefined,
+      error instanceof Error ? error : undefined,
+    );
   }
 }
 

--- a/src/commands/misc/_globals.ts
+++ b/src/commands/misc/_globals.ts
@@ -180,7 +180,7 @@ export async function updateGlobalsMessage() {
     const content = await buildGlobalsContent(gameday);
     await message.edit({ content, allowedMentions: { users: [] } });
   } catch {
-    // Message may have been deleted — silently ignore
+    // Message may have been deleted - silently ignore
   }
 }
 
@@ -189,7 +189,7 @@ export async function buildGlobals(gameday: number): Promise<string> {
     const socpData = await fetchSocpData();
     await upsertDaily("socp", gameday, socpData, true);
   } catch {
-    // SOCP fetch failed — placeholder will show
+    // SOCP fetch failed - placeholder will show
   }
 
   return await buildGlobalsContent(gameday);

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,7 +164,7 @@ async function main() {
   process.on("SIGINT", () => void shutdown("SIGINT"));
 
   process.on("uncaughtException", (err) => {
-    // Transient database connection drops — the pool replaces dead connections
+    // Transient database connection drops - the pool replaces dead connections
     if (
       err instanceof Error &&
       err.message === "Connection terminated unexpectedly"

--- a/src/server/apps/calendar/web/components/MoonOrbits.tsx
+++ b/src/server/apps/calendar/web/components/MoonOrbits.tsx
@@ -318,7 +318,7 @@ function LoathingSystem({
         />
       </mesh>
 
-      {/* Grimace — with comet impact chunk subtracted */}
+      {/* Grimace - with comet impact chunk subtracted */}
       <GrimaceMoon ref={grimaceRef} />
 
       {/* Hamburglar */}
@@ -522,7 +522,7 @@ function PhaseOverlay({
 
     const light = hambLight();
 
-    // Grimace phases — frac tweens the x position smoothly across each phase.
+    // Grimace phases - frac tweens the x position smoothly across each phase.
     // The full visible journey across Grimace is:
     //   phase 4 (appearing): slides in from left edge
     //   phase 0 (left side): slides from left toward center
@@ -538,7 +538,7 @@ function PhaseOverlay({
       gH = frac < 0.7 ? { x: 1.0 + frac * 0.6, y: 0, light } : null;
     }
 
-    // Ronald phases — same pattern:
+    // Ronald phases - same pattern:
     //   phase 7 (returning): slides in from right edge
     //   phase 8 (left side): slides from left toward center
     //   phase 9 (right side): slides from center toward right
@@ -637,7 +637,7 @@ export default function MoonOrbits({ onClose }: { onClose: () => void }) {
         }}
       >
         <span style={{ fontSize: "12px", opacity: 0.5, maxWidth: "60%" }}>
-          Work in progress — not accurate or lore-accurate. Drag to rotate,
+          Work in progress - not accurate or lore-accurate. Drag to rotate,
           scroll to zoom.
         </span>
         <button


### PR DESCRIPTION
## Problem

`checkStore` has been silently failing to record Mr. Store changes since IotM tracking went live (May 2026). Observed in the alerts channel: the May IotM `pasta wand loot box` left the store but production never recorded the removal.

## Root cause

`upsertIotmByName`'s `onConflict` targeted the **partial** unique index `Iotm_itemName_key` (`... WHERE "itemName" IS NOT NULL`) without repeating the predicate, so Postgres cannot infer it as an `ON CONFLICT` arbiter and raises `42P10` on every upsert. Verified against the live prod index (old form errors, new form succeeds).

Because `checkStore` ran as `void checkStore()` with no per-item `try/catch`, the first permanent (`subscriberItem=false`) item aborted the whole run **before** the removal-detection loop — so removals were never recorded and no non-subscriber rows ever persisted. The only writes that succeeded used plain `UPDATE` paths that don't touch `onConflict`.

## Changes

- **`onConflict` arbiter**: repeat the partial-index predicate so the upsert works.
- **`addedToStore`**: preserve the original entry on conflict via a `CASE` (only (re)set on genuine re-entry) so the true entry date isn't bumped every rollover.
- **Resilience**: isolate each item in its own `try/catch` so one failure can't skip removal detection; surface unexpected errors instead of swallowing the rejection; alert + skip on an empty fetch (rollover quirk).

## Tests / CI

- `mrstore.test.ts` — mocked `checkStore` regression tests (a failing item still runs removal detection; empty fetch skipped; urgency=Today prediction).
- `database.iotm.test.ts` — real-DB integration test for `upsertIotmByName`, gated on `DATABASE_URL`. **Proven** to fail with `42P10` on the old code and pass on the new; also checks `addedToStore` preservation/re-entry.
- `oaf.yml` — adds a throwaway Postgres service so the integration test runs in CI.

## Production data

The historical rows affected by the outage have already been backfilled directly in prod (May IotM removal recorded; June subscriber roll recreated as a nameless row). Once this deploys, the next rollover's `checkStore` will name the June row and resume normal tracking.