### PR TITLE
Bump kol.js to 0.10.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "http-status-codes": "^2.3.0",
     "js-sha256": "^0.11.1",
     "jsonwebtoken": "^9.0.3",
-    "kol.js": "^0.10.1",
+    "kol.js": "^0.10.2",
     "kysely": "^0.28.11",
     "lightstreamer-client-node": "^9.2.2",
     "pg": "^8.19.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4802,9 +4802,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"kol.js@npm:^0.10.1":
-  version: 0.10.1
-  resolution: "kol.js@npm:0.10.1"
+"kol.js@npm:^0.10.2":
+  version: 0.10.2
+  resolution: "kol.js@npm:0.10.2"
   dependencies:
     async-mutex: "npm:^0.5.0"
     chevrotain: "npm:^12.0.0"
@@ -4825,7 +4825,7 @@ __metadata:
     zod: "npm:^4.4.3"
   peerDependencies:
     data-of-loathing: ">=4.3.0"
-  checksum: 10c0/ffa6cffc14d62b7e1a144263685b5fa0406e1b790370c78397740b5c125e7ce845eab8d1f416df85ab50583f73c4a0b36dbf393ba2e03e1d5e9ade456e358f62
+  checksum: 10c0/d9098eb308dd71e2d60f5035d38babd195be9ca1f27de7eceb925700ab923b8e2e8ec5e07f208fcdb24db8e99d4764bfebfdab556f44aed15cfaeba9ac5a26b1
   languageName: node
   linkType: hard
 
@@ -5495,7 +5495,7 @@ __metadata:
     jiti: "npm:^2.6.1"
     js-sha256: "npm:^0.11.1"
     jsonwebtoken: "npm:^9.0.3"
-    kol.js: "npm:^0.10.1"
+    kol.js: "npm:^0.10.2"
     kysely: "npm:^0.28.11"
     kysely-ctl: "npm:^0.20.0"
     lightstreamer-client-node: "npm:^9.2.2"


### PR DESCRIPTION
Follow-up to #316, which merged at 0.10.1 before the 0.10.2 bump landed.

0.10.2 fixes a login regression introduced in 0.10: the schema-based `checkLoggedIn` rejected `api.php` status responses where `intrinsics`/`effects` come back as an empty array (`[]`) instead of an object, making login fail with `AuthError` for accounts with no intrinsic effects — including the bot. This is what's currently breaking chat login in prod.

Verified `client.login()` now succeeds against the live account.