### PR TITLE
Remove nightly Mr. Store printout from alerts

### DIFF
--- a/migrations/1781280000000_iotm_currency.ts
+++ b/migrations/1781280000000_iotm_currency.ts
@@ -1,0 +1,13 @@
+import { type Kysely, sql } from "kysely";
+
+export async function up(db: Kysely<never>): Promise<void> {
+  await sql`
+    ALTER TABLE "Iotm"
+      ADD COLUMN IF NOT EXISTS "currency" TEXT NOT NULL DEFAULT 'mr_accessory'
+      CHECK ("currency" IN ('mr_accessory', 'uncle_buck'))
+  `.execute(db);
+}
+
+export async function down(db: Kysely<never>): Promise<void> {
+  await sql`ALTER TABLE "Iotm" DROP COLUMN "currency"`.execute(db);
+}

--- a/src/clients/database.iotm.test.ts
+++ b/src/clients/database.iotm.test.ts
@@ -36,6 +36,7 @@ describeIfDb("upsertIotmByName (integration)", () => {
         "itemImage" TEXT,
         "month" DATE NOT NULL,
         "mraCost" INTEGER NOT NULL DEFAULT 1,
+        "currency" TEXT NOT NULL DEFAULT 'mr_accessory',
         "subscriberItem" BOOLEAN NOT NULL DEFAULT false,
         "addedToStore" TIMESTAMPTZ,
         "removedFromStore" TIMESTAMPTZ,

--- a/src/clients/database.iotm.test.ts
+++ b/src/clients/database.iotm.test.ts
@@ -17,12 +17,8 @@ vi.mock("../config.js", () => ({
   config: { DATABASE_URL: process.env.DATABASE_URL },
 }));
 
-const {
-  db,
-  upsertIotmByName,
-  setIotmRemovedFromStore,
-  getIotmEventsForDateRange,
-} = await import("./database.js");
+const { db, upsertIotmByName, setIotmRemovedFromStore } =
+  await import("./database.js");
 
 const NAME = "__test_iotm_upsert__";
 const MONTH = new Date("2099-01-01");
@@ -124,36 +120,5 @@ describeIfDb("upsertIotmByName (integration)", () => {
       .where("itemName", "=", NAME)
       .executeTakeFirstOrThrow();
     expect(row.addedToStore?.toISOString()).toBe(reentry.toISOString());
-  });
-
-  // The calendar only shows Items of the Month; non-subscriber Mr. Store stock is
-  // tracked in the same table but must be excluded from the event feed.
-  test("getIotmEventsForDateRange excludes non-subscriber store stock", async () => {
-    const PERM = "__test_iotm_perm__";
-    const added = new Date("2099-01-10T03:30:00Z");
-    try {
-      await upsertIotmByName({
-        itemName: NAME,
-        month: MONTH,
-        subscriberItem: true,
-        addedToStore: added,
-      });
-      await upsertIotmByName({
-        itemName: PERM,
-        month: MONTH,
-        subscriberItem: false,
-        addedToStore: added,
-      });
-
-      const events = await getIotmEventsForDateRange(
-        new Date("2099-01-01T00:00:00Z"),
-        new Date("2099-02-01T00:00:00Z"),
-      );
-      const names = events.map((e) => e.itemName);
-      expect(names).toContain(NAME);
-      expect(names).not.toContain(PERM);
-    } finally {
-      await db.deleteFrom("Iotm").where("itemName", "=", PERM).execute();
-    }
   });
 });

--- a/src/clients/database.iotm.test.ts
+++ b/src/clients/database.iotm.test.ts
@@ -17,8 +17,12 @@ vi.mock("../config.js", () => ({
   config: { DATABASE_URL: process.env.DATABASE_URL },
 }));
 
-const { db, upsertIotmByName, setIotmRemovedFromStore } =
-  await import("./database.js");
+const {
+  db,
+  upsertIotmByName,
+  setIotmRemovedFromStore,
+  getIotmEventsForDateRange,
+} = await import("./database.js");
 
 const NAME = "__test_iotm_upsert__";
 const MONTH = new Date("2099-01-01");
@@ -120,5 +124,36 @@ describeIfDb("upsertIotmByName (integration)", () => {
       .where("itemName", "=", NAME)
       .executeTakeFirstOrThrow();
     expect(row.addedToStore?.toISOString()).toBe(reentry.toISOString());
+  });
+
+  // The calendar only shows Items of the Month; non-subscriber Mr. Store stock is
+  // tracked in the same table but must be excluded from the event feed.
+  test("getIotmEventsForDateRange excludes non-subscriber store stock", async () => {
+    const PERM = "__test_iotm_perm__";
+    const added = new Date("2099-01-10T03:30:00Z");
+    try {
+      await upsertIotmByName({
+        itemName: NAME,
+        month: MONTH,
+        subscriberItem: true,
+        addedToStore: added,
+      });
+      await upsertIotmByName({
+        itemName: PERM,
+        month: MONTH,
+        subscriberItem: false,
+        addedToStore: added,
+      });
+
+      const events = await getIotmEventsForDateRange(
+        new Date("2099-01-01T00:00:00Z"),
+        new Date("2099-02-01T00:00:00Z"),
+      );
+      const names = events.map((e) => e.itemName);
+      expect(names).toContain(NAME);
+      expect(names).not.toContain(PERM);
+    } finally {
+      await db.deleteFrom("Iotm").where("itemName", "=", PERM).execute();
+    }
   });
 });

--- a/src/clients/database.ts
+++ b/src/clients/database.ts
@@ -1139,7 +1139,6 @@ export async function getIotmEventsForDateRange(from: Date, to: Date) {
   return await db
     .selectFrom("Iotm")
     .selectAll()
-    .where("subscriberItem", "=", true)
     .where((eb) =>
       eb.or([
         eb.and([eb("addedToStore", ">=", from), eb("addedToStore", "<=", to)]),

--- a/src/clients/database.ts
+++ b/src/clients/database.ts
@@ -1139,6 +1139,7 @@ export async function getIotmEventsForDateRange(from: Date, to: Date) {
   return await db
     .selectFrom("Iotm")
     .selectAll()
+    .where("subscriberItem", "=", true)
     .where((eb) =>
       eb.or([
         eb.and([eb("addedToStore", ">=", from), eb("addedToStore", "<=", to)]),

--- a/src/clients/database.ts
+++ b/src/clients/database.ts
@@ -1022,6 +1022,7 @@ export async function upsertIotmByName(data: {
   itemImage?: string | null;
   month: Date;
   mraCost?: number;
+  currency?: "mr_accessory" | "uncle_buck";
   subscriberItem?: boolean;
   addedToStore?: Date | null;
 }) {
@@ -1042,6 +1043,7 @@ export async function upsertIotmByName(data: {
         itemDescid: data.itemDescid ?? null,
         itemImage: data.itemImage ?? null,
         mraCost: data.mraCost,
+        currency: data.currency,
         addedToStore: data.addedToStore ?? null,
       })
       .where("id", "=", existing.id)
@@ -1057,6 +1059,7 @@ export async function upsertIotmByName(data: {
       itemImage: data.itemImage ?? null,
       month: data.month,
       ...(data.mraCost !== undefined && { mraCost: data.mraCost }),
+      currency: data.currency,
       subscriberItem: data.subscriberItem ?? false,
       addedToStore: data.addedToStore ?? null,
     })
@@ -1070,6 +1073,7 @@ export async function upsertIotmByName(data: {
           itemDescid: data.itemDescid ?? null,
           itemImage: data.itemImage ?? null,
           ...(data.mraCost !== undefined && { mraCost: data.mraCost }),
+          currency: data.currency,
           // Preserve the original entry; only (re)set addedToStore when the item
           // is genuinely (re-)entering - previously removed, or never recorded.
           addedToStore: sql`CASE WHEN ${eb.ref("Iotm.removedFromStore")} IS NOT NULL OR ${eb.ref("Iotm.addedToStore")} IS NULL THEN ${eb.ref("excluded.addedToStore")} ELSE ${eb.ref("Iotm.addedToStore")} END`,

--- a/src/commands/kol/mrstore.test.ts
+++ b/src/commands/kol/mrstore.test.ts
@@ -52,25 +52,16 @@ vi.mock("kol.js/domains/MrStore", () => ({
 
 const { checkStore } = await import("./mrstore.js");
 
-function item(
-  name: string,
-  urgency = 0,
-  category = "June's Item-of-the-Month",
-): MrStoreItem {
+function item(name: string, urgency = 0): MrStoreItem {
   return {
     name,
     descid: 1,
     image: `${name}.gif`,
     cost: 1,
     currency: "mr_accessory",
-    category,
+    category: "Stuff",
     urgency: urgency as MrStoreItem["urgency"],
   };
-}
-
-// Permanent Mr. Store stock (Mr. Accessories, name-change form, etc.) - not an IotM.
-function permanent(name: string): MrStoreItem {
-  return item(name, 0, "Mr. Accessory Store");
 }
 
 beforeEach(() => {
@@ -120,55 +111,6 @@ describe("checkStore", () => {
     expect(setIotmRemovedFromStore).toHaveBeenCalledWith(
       "leaving",
       new Date("2026-06-11T03:30:00Z"),
-    );
-  });
-
-  // Mr. Store lists the current IotM alongside permanent stock (Mr. Accessories,
-  // name-change form, etc.). Only the actual Item of the Month should be tracked.
-  test("only Item-of-the-Month items are upserted; permanent stock is skipped", async () => {
-    getCurrentItems.mockResolvedValue([
-      permanent("Golden Mr. Accessory"),
-      item("scabbarded Sword of S Words"),
-      permanent("name change form"),
-      permanent("Monster Manuel"),
-    ]);
-    upsertIotmByName.mockResolvedValue(undefined);
-
-    await checkStore();
-
-    expect(upsertIotmByName).toHaveBeenCalledTimes(1);
-    expect(upsertIotmByName).toHaveBeenCalledWith(
-      expect.objectContaining({
-        itemName: "scabbarded Sword of S Words",
-        subscriberItem: true,
-      }),
-    );
-    for (const name of [
-      "Golden Mr. Accessory",
-      "name change form",
-      "Monster Manuel",
-    ]) {
-      expect(upsertIotmByName).not.toHaveBeenCalledWith(
-        expect.objectContaining({ itemName: name }),
-      );
-    }
-  });
-
-  // If KoL changes the category format so nothing matches, a non-empty fetch must be
-  // treated as untrustworthy - alerting rather than marking the live IotM as removed.
-  test("a non-empty fetch with no IotM-category items is skipped without touching the database", async () => {
-    getCurrentItems.mockResolvedValue([
-      permanent("Golden Mr. Accessory"),
-      permanent("name change form"),
-    ]);
-
-    await checkStore();
-
-    expect(upsertIotmByName).not.toHaveBeenCalled();
-    expect(getIotmsInStore).not.toHaveBeenCalled();
-    expect(setIotmRemovedFromStore).not.toHaveBeenCalled();
-    expect(alert).toHaveBeenCalledWith(
-      expect.stringContaining("none matched the IotM category"),
     );
   });
 

--- a/src/commands/kol/mrstore.test.ts
+++ b/src/commands/kol/mrstore.test.ts
@@ -52,16 +52,25 @@ vi.mock("kol.js/domains/MrStore", () => ({
 
 const { checkStore } = await import("./mrstore.js");
 
-function item(name: string, urgency = 0): MrStoreItem {
+function item(
+  name: string,
+  urgency = 0,
+  category = "June's Item-of-the-Month",
+): MrStoreItem {
   return {
     name,
     descid: 1,
     image: `${name}.gif`,
     cost: 1,
     currency: "mr_accessory",
-    category: "Stuff",
+    category,
     urgency: urgency as MrStoreItem["urgency"],
   };
+}
+
+// Permanent Mr. Store stock (Mr. Accessories, name-change form, etc.) - not an IotM.
+function permanent(name: string): MrStoreItem {
+  return item(name, 0, "Mr. Accessory Store");
 }
 
 beforeEach(() => {
@@ -76,8 +85,9 @@ describe("checkStore", () => {
   // IotM "pasta wand loot box") was never marked as removed.
   test("a failing item does not skip removal detection for other items", async () => {
     getCurrentItems.mockResolvedValue([item("first"), item("second")]);
-    upsertIotmByName.mockImplementation(async ({ itemName }) => {
+    upsertIotmByName.mockImplementation(({ itemName }) => {
       if (itemName === "first") throw new Error("boom");
+      return Promise.resolve();
     });
     // "departed" was tracked previously but is no longer in the store.
     getIotmsInStore.mockResolvedValue([{ itemName: "departed" }]);
@@ -110,6 +120,55 @@ describe("checkStore", () => {
     expect(setIotmRemovedFromStore).toHaveBeenCalledWith(
       "leaving",
       new Date("2026-06-11T03:30:00Z"),
+    );
+  });
+
+  // Mr. Store lists the current IotM alongside permanent stock (Mr. Accessories,
+  // name-change form, etc.). Only the actual Item of the Month should be tracked.
+  test("only Item-of-the-Month items are upserted; permanent stock is skipped", async () => {
+    getCurrentItems.mockResolvedValue([
+      permanent("Golden Mr. Accessory"),
+      item("scabbarded Sword of S Words"),
+      permanent("name change form"),
+      permanent("Monster Manuel"),
+    ]);
+    upsertIotmByName.mockResolvedValue(undefined);
+
+    await checkStore();
+
+    expect(upsertIotmByName).toHaveBeenCalledTimes(1);
+    expect(upsertIotmByName).toHaveBeenCalledWith(
+      expect.objectContaining({
+        itemName: "scabbarded Sword of S Words",
+        subscriberItem: true,
+      }),
+    );
+    for (const name of [
+      "Golden Mr. Accessory",
+      "name change form",
+      "Monster Manuel",
+    ]) {
+      expect(upsertIotmByName).not.toHaveBeenCalledWith(
+        expect.objectContaining({ itemName: name }),
+      );
+    }
+  });
+
+  // If KoL changes the category format so nothing matches, a non-empty fetch must be
+  // treated as untrustworthy - alerting rather than marking the live IotM as removed.
+  test("a non-empty fetch with no IotM-category items is skipped without touching the database", async () => {
+    getCurrentItems.mockResolvedValue([
+      permanent("Golden Mr. Accessory"),
+      permanent("name change form"),
+    ]);
+
+    await checkStore();
+
+    expect(upsertIotmByName).not.toHaveBeenCalled();
+    expect(getIotmsInStore).not.toHaveBeenCalled();
+    expect(setIotmRemovedFromStore).not.toHaveBeenCalled();
+    expect(alert).toHaveBeenCalledWith(
+      expect.stringContaining("none matched the IotM category"),
     );
   });
 

--- a/src/commands/kol/mrstore.test.ts
+++ b/src/commands/kol/mrstore.test.ts
@@ -127,4 +127,20 @@ describe("checkStore", () => {
       "checkStore: store fetch was empty - skipping (possible rollover quirk)",
     );
   });
+
+  test("passes the item currency through to the database", async () => {
+    getCurrentItems.mockResolvedValue([
+      { ...item("uncle buck thing"), currency: "uncle_buck" },
+    ]);
+    upsertIotmByName.mockResolvedValue(undefined);
+
+    await checkStore();
+
+    expect(upsertIotmByName).toHaveBeenCalledWith(
+      expect.objectContaining({
+        itemName: "uncle buck thing",
+        currency: "uncle_buck",
+      }),
+    );
+  });
 });

--- a/src/commands/kol/mrstore.ts
+++ b/src/commands/kol/mrstore.ts
@@ -48,20 +48,23 @@ export async function checkStore() {
     const currentNames = new Set<string>();
 
     for (const item of items) {
+      // Mr. Store lists the current IotM alongside permanent stock (Mr. Accessories,
+      // name-change form, etc.). Only the actual Item of the Month - whose category
+      // is e.g. "June's Item-of-the-Month" - should be tracked.
+      if (!IOTM_CATEGORY_PATTERN.test(item.category)) continue;
+
       currentNames.add(item.name);
 
       // Isolate each item so one failure can't abort the whole run (and,
       // crucially, can't skip the removal-detection loop below).
       try {
-        const subscriberItem = IOTM_CATEGORY_PATTERN.test(item.category);
-
         await upsertIotmByName({
           itemName: item.name,
           itemDescid: item.descid,
           itemImage: item.image,
           month,
           mraCost: item.cost,
-          subscriberItem,
+          subscriberItem: true,
           addedToStore: now,
         });
 
@@ -83,6 +86,16 @@ export async function checkStore() {
           error instanceof Error ? error : undefined,
         );
       }
+    }
+
+    // If a non-empty fetch yielded no IotM, KoL has likely changed the category
+    // format. Treat it as untrustworthy (like an empty fetch) rather than running
+    // removal-detection, which would wrongly mark the live IotM as removed.
+    if (currentNames.size === 0) {
+      void discordClient.alert(
+        `checkStore: fetched ${items.length} item(s) but none matched the IotM category - store format may have changed; skipping`,
+      );
+      return;
     }
 
     // Mark any previously-tracked items no longer in the store as removed

--- a/src/commands/kol/mrstore.ts
+++ b/src/commands/kol/mrstore.ts
@@ -48,23 +48,20 @@ export async function checkStore() {
     const currentNames = new Set<string>();
 
     for (const item of items) {
-      // Mr. Store lists the current IotM alongside permanent stock (Mr. Accessories,
-      // name-change form, etc.). Only the actual Item of the Month - whose category
-      // is e.g. "June's Item-of-the-Month" - should be tracked.
-      if (!IOTM_CATEGORY_PATTERN.test(item.category)) continue;
-
       currentNames.add(item.name);
 
       // Isolate each item so one failure can't abort the whole run (and,
       // crucially, can't skip the removal-detection loop below).
       try {
+        const subscriberItem = IOTM_CATEGORY_PATTERN.test(item.category);
+
         await upsertIotmByName({
           itemName: item.name,
           itemDescid: item.descid,
           itemImage: item.image,
           month,
           mraCost: item.cost,
-          subscriberItem: true,
+          subscriberItem,
           addedToStore: now,
         });
 
@@ -86,16 +83,6 @@ export async function checkStore() {
           error instanceof Error ? error : undefined,
         );
       }
-    }
-
-    // If a non-empty fetch yielded no IotM, KoL has likely changed the category
-    // format. Treat it as untrustworthy (like an empty fetch) rather than running
-    // removal-detection, which would wrongly mark the live IotM as removed.
-    if (currentNames.size === 0) {
-      void discordClient.alert(
-        `checkStore: fetched ${items.length} item(s) but none matched the IotM category - store format may have changed; skipping`,
-      );
-      return;
     }
 
     // Mark any previously-tracked items no longer in the store as removed

--- a/src/commands/kol/mrstore.ts
+++ b/src/commands/kol/mrstore.ts
@@ -29,10 +29,6 @@ export async function checkStore() {
   }
 
   try {
-    void discordClient.alert(
-      `checkStore: fetched ${items.length} item(s) - ${items.map((i) => `${i.name} (urgency=${i.urgency})`).join(", ") || "none"}`,
-    );
-
     // An empty fetch is treated as untrustworthy (the API returns {} during
     // rollover) - skip rather than mark every tracked item as removed.
     if (items.length === 0) {

--- a/src/commands/kol/mrstore.ts
+++ b/src/commands/kol/mrstore.ts
@@ -57,6 +57,7 @@ export async function checkStore() {
           itemImage: item.image,
           month,
           mraCost: item.cost,
+          currency: item.currency,
           subscriberItem,
           addedToStore: now,
         });

--- a/src/database-types.ts
+++ b/src/database-types.ts
@@ -112,6 +112,7 @@ export interface IotmTable {
   itemImage: string | null;
   month: ColumnType<Date, Date | string, Date | string>;
   mraCost: Generated<number>;
+  currency: Generated<"mr_accessory" | "uncle_buck">;
   subscriberItem: Generated<boolean>;
   addedToStore: ColumnType<
     Date | null,


### PR DESCRIPTION
`checkStore` logged every fetched Mr. Store item to the alerts channel on each rollover (added to diagnose the rollover behaviour). The feature works now, so this drops the nightly printout.

Mr. Store stock continues to be tracked, and the calendar shows store comings/goings for all items. Prod data was corrected separately: the 8 permanents that had been stamped with a bogus 2026-06-11 entry date were re-seeded with accurate historical entry dates, and two departed items (Horsery contract, deed to Oliver's Place) were backfilled.