### PR TITLE
Rename Iotm table to MrStoreItem and add category

### DIFF
--- a/migrations/1781280001000_mr_store_item.ts
+++ b/migrations/1781280001000_mr_store_item.ts
@@ -1,0 +1,82 @@
+import { type Kysely, sql } from "kysely";
+
+// Renames the "Iotm" table to "MrStoreItem" (it now tracks every Mr. Store item,
+// not just items-of-the-month), adds a "category" column (iotm | ioty | other) and
+// makes "month" nullable (NULL for permanent "other" items). The category backfill
+// here is generic (subscriberItem -> iotm/other); the IoTY reclassification and the
+// missing Oct 2024 non-subscriber IotM are applied separately via prod ssh.
+
+export async function up(db: Kysely<never>): Promise<void> {
+  // Rename the table and its dependent objects (Postgres does not auto-rename these)
+  await sql`ALTER TABLE "Iotm" RENAME TO "MrStoreItem"`.execute(db);
+  await sql`ALTER SEQUENCE "Iotm_id_seq" RENAME TO "MrStoreItem_id_seq"`.execute(
+    db,
+  );
+  await sql`ALTER INDEX "Iotm_pkey" RENAME TO "MrStoreItem_pkey"`.execute(db);
+  await sql`ALTER INDEX "Iotm_itemName_key" RENAME TO "MrStoreItem_itemName_key"`.execute(
+    db,
+  );
+  await sql`ALTER TABLE "MrStoreItem" RENAME CONSTRAINT "Iotm_currency_check" TO "MrStoreItem_currency_check"`.execute(
+    db,
+  );
+
+  // Add category nullable first - the table is non-empty so a NOT NULL add would fail
+  await sql`ALTER TABLE "MrStoreItem" ADD COLUMN "category" TEXT`.execute(db);
+
+  // Generic backfill: subscriber items are items-of-the-month, the rest are permanent
+  await sql`
+    UPDATE "MrStoreItem"
+    SET "category" = CASE WHEN "subscriberItem" THEN 'iotm' ELSE 'other' END
+  `.execute(db);
+
+  // Now enforce NOT NULL + the allowed values
+  await sql`ALTER TABLE "MrStoreItem" ALTER COLUMN "category" SET NOT NULL`.execute(
+    db,
+  );
+  await sql`
+    ALTER TABLE "MrStoreItem"
+    ADD CONSTRAINT "MrStoreItem_category_check"
+    CHECK ("category" IN ('iotm', 'ioty', 'other'))
+  `.execute(db);
+
+  // Permanent items have no meaningful month
+  await sql`ALTER TABLE "MrStoreItem" ALTER COLUMN "month" DROP NOT NULL`.execute(
+    db,
+  );
+  await sql`UPDATE "MrStoreItem" SET "month" = NULL WHERE "category" = 'other'`.execute(
+    db,
+  );
+}
+
+export async function down(db: Kysely<never>): Promise<void> {
+  // Lossy: the iotm/ioty/other distinction is dropped, and months nulled in up()
+  // are reconstructed approximately from store timestamps.
+  await sql`ALTER TABLE "MrStoreItem" DROP CONSTRAINT "MrStoreItem_category_check"`.execute(
+    db,
+  );
+  await sql`ALTER TABLE "MrStoreItem" DROP COLUMN "category"`.execute(db);
+
+  await sql`
+    UPDATE "MrStoreItem"
+    SET "month" = date_trunc(
+      'month',
+      COALESCE("addedToStore", "distributedToSubscribers", now())
+    )::date
+    WHERE "month" IS NULL
+  `.execute(db);
+  await sql`ALTER TABLE "MrStoreItem" ALTER COLUMN "month" SET NOT NULL`.execute(
+    db,
+  );
+
+  await sql`ALTER TABLE "MrStoreItem" RENAME CONSTRAINT "MrStoreItem_currency_check" TO "Iotm_currency_check"`.execute(
+    db,
+  );
+  await sql`ALTER INDEX "MrStoreItem_itemName_key" RENAME TO "Iotm_itemName_key"`.execute(
+    db,
+  );
+  await sql`ALTER INDEX "MrStoreItem_pkey" RENAME TO "Iotm_pkey"`.execute(db);
+  await sql`ALTER SEQUENCE "MrStoreItem_id_seq" RENAME TO "Iotm_id_seq"`.execute(
+    db,
+  );
+  await sql`ALTER TABLE "MrStoreItem" RENAME TO "Iotm"`.execute(db);
+}

--- a/migrations/1781280001000_mr_store_item.ts
+++ b/migrations/1781280001000_mr_store_item.ts
@@ -2,9 +2,8 @@ import { type Kysely, sql } from "kysely";
 
 // Renames the "Iotm" table to "MrStoreItem" (it now tracks every Mr. Store item,
 // not just items-of-the-month), adds a "category" column (iotm | ioty | other) and
-// makes "month" nullable (NULL for permanent "other" items). The category backfill
-// here is generic (subscriberItem -> iotm/other); the IoTY reclassification and the
-// missing Oct 2024 non-subscriber IotM are applied separately via prod ssh.
+// makes "month" nullable (NULL for permanent "other" items). The missing Oct 2024
+// non-subscriber IotM ("photo booth sized crate") is inserted separately via prod ssh.
 
 export async function up(db: Kysely<never>): Promise<void> {
   // Rename the table and its dependent objects (Postgres does not auto-rename these)
@@ -27,6 +26,20 @@ export async function up(db: Kysely<never>): Promise<void> {
   await sql`
     UPDATE "MrStoreItem"
     SET "category" = CASE WHEN "subscriberItem" THEN 'iotm' ELSE 'other' END
+  `.execute(db);
+
+  // Reclassify the Items-of-the-Year (Jan 2023 onward). These rows only exist in
+  // prod (they were inserted at runtime, not seeded), so this no-ops on a fresh DB.
+  // Must run before the month-nulling below so they keep their January months.
+  await sql`
+    UPDATE "MrStoreItem"
+    SET "category" = 'ioty'
+    WHERE "itemName" IN (
+      'unoccupied sheep suit',
+      'Black and White Apron Enrollment Form',
+      'CyberRealm keycode',
+      'discreetly-wrapped Eternity Codpiece'
+    )
   `.execute(db);
 
   // Now enforce NOT NULL + the allowed values

--- a/src/clients/database.mrStoreItem.test.ts
+++ b/src/clients/database.mrStoreItem.test.ts
@@ -9,34 +9,35 @@ import {
   vi,
 } from "vitest";
 
-// This is a real-database integration test for upsertIotmByName. It only runs when
-// a DATABASE_URL is provided (skipped otherwise, e.g. local `yarn test` without a
-// DB); CI supplies a throwaway Postgres service. We inject the URL into `config`
-// because src/config.ts deliberately returns `{}` under Vitest.
+// This is a real-database integration test for upsertMrStoreItemByName. It only
+// runs when a DATABASE_URL is provided (skipped otherwise, e.g. local `yarn test`
+// without a DB); CI supplies a throwaway Postgres service. We inject the URL into
+// `config` because src/config.ts deliberately returns `{}` under Vitest.
 vi.mock("../config.js", () => ({
   config: { DATABASE_URL: process.env.DATABASE_URL },
 }));
 
-const { db, upsertIotmByName, setIotmRemovedFromStore } =
+const { db, upsertMrStoreItemByName, setMrStoreItemRemovedFromStore } =
   await import("./database.js");
 
-const NAME = "__test_iotm_upsert__";
+const NAME = "__test_mrstoreitem_upsert__";
 const MONTH = new Date("2099-01-01");
 
 const describeIfDb = process.env.DATABASE_URL ? describe : describe.skip;
 
-describeIfDb("upsertIotmByName (integration)", () => {
+describeIfDb("upsertMrStoreItemByName (integration)", () => {
   beforeAll(async () => {
     // Mirror the real schema so ON CONFLICT hits the same *partial* unique index.
     await sql`
-      CREATE TABLE IF NOT EXISTS "Iotm" (
+      CREATE TABLE IF NOT EXISTS "MrStoreItem" (
         "id" SERIAL PRIMARY KEY,
         "itemName" TEXT,
         "itemDescid" INTEGER,
         "itemImage" TEXT,
-        "month" DATE NOT NULL,
+        "month" DATE,
         "mraCost" INTEGER NOT NULL DEFAULT 1,
         "currency" TEXT NOT NULL DEFAULT 'mr_accessory',
+        "category" TEXT NOT NULL CHECK ("category" IN ('iotm', 'ioty', 'other')),
         "subscriberItem" BOOLEAN NOT NULL DEFAULT false,
         "addedToStore" TIMESTAMPTZ,
         "removedFromStore" TIMESTAMPTZ,
@@ -44,17 +45,17 @@ describeIfDb("upsertIotmByName (integration)", () => {
       )
     `.execute(db);
     await sql`
-      CREATE UNIQUE INDEX IF NOT EXISTS "Iotm_itemName_key"
-      ON "Iotm" ("itemName") WHERE "itemName" IS NOT NULL
+      CREATE UNIQUE INDEX IF NOT EXISTS "MrStoreItem_itemName_key"
+      ON "MrStoreItem" ("itemName") WHERE "itemName" IS NOT NULL
     `.execute(db);
   });
 
   beforeEach(async () => {
-    await db.deleteFrom("Iotm").where("itemName", "=", NAME).execute();
+    await db.deleteFrom("MrStoreItem").where("itemName", "=", NAME).execute();
   });
 
   afterAll(async () => {
-    await db.deleteFrom("Iotm").where("itemName", "=", NAME).execute();
+    await db.deleteFrom("MrStoreItem").where("itemName", "=", NAME).execute();
     await db.destroy();
   });
 
@@ -62,16 +63,18 @@ describeIfDb("upsertIotmByName (integration)", () => {
   // NULL). Without repeating that predicate in the ON CONFLICT target, Postgres
   // raises 42P10 on every upsert, which silently aborted checkStore.
   test("a conflicting upsert does not throw", async () => {
-    await upsertIotmByName({
+    await upsertMrStoreItemByName({
       itemName: NAME,
+      category: "iotm",
       month: MONTH,
       subscriberItem: false,
       addedToStore: new Date("2099-01-01T03:30:00Z"),
     });
 
     await expect(
-      upsertIotmByName({
+      upsertMrStoreItemByName({
         itemName: NAME,
+        category: "iotm",
         month: MONTH,
         subscriberItem: false,
         addedToStore: new Date("2099-02-01T03:30:00Z"),
@@ -83,40 +86,46 @@ describeIfDb("upsertIotmByName (integration)", () => {
   // rollover the item stays in the store.
   test("addedToStore is preserved while the item stays in store, and reset on re-entry", async () => {
     const entry = new Date("2099-01-01T03:30:00Z");
-    await upsertIotmByName({
+    await upsertMrStoreItemByName({
       itemName: NAME,
+      category: "iotm",
       month: MONTH,
       subscriberItem: false,
       addedToStore: entry,
     });
 
     // Still in store on a later rollover - entry must be preserved.
-    await upsertIotmByName({
+    await upsertMrStoreItemByName({
       itemName: NAME,
+      category: "iotm",
       month: MONTH,
       subscriberItem: false,
       addedToStore: new Date("2099-02-01T03:30:00Z"),
     });
 
     let row = await db
-      .selectFrom("Iotm")
+      .selectFrom("MrStoreItem")
       .select("addedToStore")
       .where("itemName", "=", NAME)
       .executeTakeFirstOrThrow();
     expect(row.addedToStore?.toISOString()).toBe(entry.toISOString());
 
     // Item leaves, then re-enters later - entry should now update.
-    await setIotmRemovedFromStore(NAME, new Date("2099-02-15T03:30:00Z"));
+    await setMrStoreItemRemovedFromStore(
+      NAME,
+      new Date("2099-02-15T03:30:00Z"),
+    );
     const reentry = new Date("2099-03-01T03:30:00Z");
-    await upsertIotmByName({
+    await upsertMrStoreItemByName({
       itemName: NAME,
+      category: "iotm",
       month: MONTH,
       subscriberItem: false,
       addedToStore: reentry,
     });
 
     row = await db
-      .selectFrom("Iotm")
+      .selectFrom("MrStoreItem")
       .select("addedToStore")
       .where("itemName", "=", NAME)
       .executeTakeFirstOrThrow();

--- a/src/clients/database.ts
+++ b/src/clients/database.ts
@@ -1014,50 +1014,55 @@ export async function getLatestDailies() {
   return results.rows;
 }
 
-// ── Iotm ──
+// ── MrStoreItem ──
 
-export async function upsertIotmByName(data: {
+export async function upsertMrStoreItemByName(data: {
   itemName: string;
   itemDescid?: number | null;
   itemImage?: string | null;
-  month: Date;
+  category: "iotm" | "ioty" | "other";
+  month?: Date | null;
   mraCost?: number;
   currency?: "mr_accessory" | "uncle_buck";
   subscriberItem?: boolean;
   addedToStore?: Date | null;
 }) {
-  // Check if there's an existing nameless subscriber row for this month we should claim
-  const existing = await db
-    .selectFrom("Iotm")
-    .selectAll()
-    .where("month", "=", data.month)
-    .where("subscriberItem", "=", data.subscriberItem ?? false)
-    .where("itemName", "is", null)
-    .executeTakeFirst();
+  // Subscriber items may have a nameless row pre-created for this month by the
+  // subs-rolling webhook (upsertSubsRoll); claim it rather than inserting a dupe.
+  if (data.subscriberItem && data.month) {
+    const existing = await db
+      .selectFrom("MrStoreItem")
+      .selectAll()
+      .where("month", "=", data.month)
+      .where("subscriberItem", "=", true)
+      .where("itemName", "is", null)
+      .executeTakeFirst();
 
-  if (existing) {
-    await db
-      .updateTable("Iotm")
-      .set({
-        itemName: data.itemName,
-        itemDescid: data.itemDescid ?? null,
-        itemImage: data.itemImage ?? null,
-        mraCost: data.mraCost,
-        currency: data.currency,
-        addedToStore: data.addedToStore ?? null,
-      })
-      .where("id", "=", existing.id)
-      .execute();
-    return;
+    if (existing) {
+      await db
+        .updateTable("MrStoreItem")
+        .set({
+          itemName: data.itemName,
+          itemDescid: data.itemDescid ?? null,
+          itemImage: data.itemImage ?? null,
+          mraCost: data.mraCost,
+          currency: data.currency,
+          addedToStore: data.addedToStore ?? null,
+        })
+        .where("id", "=", existing.id)
+        .execute();
+      return;
+    }
   }
 
   await db
-    .insertInto("Iotm")
+    .insertInto("MrStoreItem")
     .values({
       itemName: data.itemName,
       itemDescid: data.itemDescid ?? null,
       itemImage: data.itemImage ?? null,
-      month: data.month,
+      category: data.category,
+      month: data.month ?? null,
       ...(data.mraCost !== undefined && { mraCost: data.mraCost }),
       currency: data.currency,
       subscriberItem: data.subscriberItem ?? false,
@@ -1076,7 +1081,7 @@ export async function upsertIotmByName(data: {
           currency: data.currency,
           // Preserve the original entry; only (re)set addedToStore when the item
           // is genuinely (re-)entering - previously removed, or never recorded.
-          addedToStore: sql`CASE WHEN ${eb.ref("Iotm.removedFromStore")} IS NOT NULL OR ${eb.ref("Iotm.addedToStore")} IS NULL THEN ${eb.ref("excluded.addedToStore")} ELSE ${eb.ref("Iotm.addedToStore")} END`,
+          addedToStore: sql`CASE WHEN ${eb.ref("MrStoreItem.removedFromStore")} IS NOT NULL OR ${eb.ref("MrStoreItem.addedToStore")} IS NULL THEN ${eb.ref("excluded.addedToStore")} ELSE ${eb.ref("MrStoreItem.addedToStore")} END`,
         })),
     )
     .execute();
@@ -1084,7 +1089,7 @@ export async function upsertIotmByName(data: {
 
 export async function upsertSubsRoll(month: Date, distributedAt: Date) {
   const existing = await db
-    .selectFrom("Iotm")
+    .selectFrom("MrStoreItem")
     .selectAll()
     .where("month", "=", month)
     .where("subscriberItem", "=", true)
@@ -1092,7 +1097,7 @@ export async function upsertSubsRoll(month: Date, distributedAt: Date) {
 
   if (existing) {
     await db
-      .updateTable("Iotm")
+      .updateTable("MrStoreItem")
       .set({ distributedToSubscribers: distributedAt })
       .where("id", "=", existing.id)
       .execute();
@@ -1100,38 +1105,39 @@ export async function upsertSubsRoll(month: Date, distributedAt: Date) {
   }
 
   await db
-    .insertInto("Iotm")
+    .insertInto("MrStoreItem")
     .values({
       month,
+      category: "iotm",
       subscriberItem: true,
       distributedToSubscribers: distributedAt,
     })
     .execute();
 }
 
-export async function setIotmRemovedFromStore(
+export async function setMrStoreItemRemovedFromStore(
   itemName: string,
   removedAt: Date,
 ) {
   await db
-    .updateTable("Iotm")
+    .updateTable("MrStoreItem")
     .set({ removedFromStore: removedAt })
     .where("itemName", "=", itemName)
     .where("removedFromStore", "is", null)
     .execute();
 }
 
-export async function clearIotmRemovedFromStore(itemName: string) {
+export async function clearMrStoreItemRemovedFromStore(itemName: string) {
   await db
-    .updateTable("Iotm")
+    .updateTable("MrStoreItem")
     .set({ removedFromStore: null })
     .where("itemName", "=", itemName)
     .execute();
 }
 
-export async function getIotmsInStore() {
+export async function getMrStoreItemsInStore() {
   return await db
-    .selectFrom("Iotm")
+    .selectFrom("MrStoreItem")
     .selectAll()
     .where("addedToStore", "is not", null)
     .where("removedFromStore", "is", null)
@@ -1139,9 +1145,9 @@ export async function getIotmsInStore() {
     .execute();
 }
 
-export async function getIotmEventsForDateRange(from: Date, to: Date) {
+export async function getMrStoreItemEventsForDateRange(from: Date, to: Date) {
   return await db
-    .selectFrom("Iotm")
+    .selectFrom("MrStoreItem")
     .selectAll()
     .where((eb) =>
       eb.or([
@@ -1159,9 +1165,9 @@ export async function getIotmEventsForDateRange(from: Date, to: Date) {
     .execute();
 }
 
-export async function getIotmsForDateRange(from: Date, to: Date) {
+export async function getMrStoreItemsForDateRange(from: Date, to: Date) {
   return await db
-    .selectFrom("Iotm")
+    .selectFrom("MrStoreItem")
     .selectAll()
     .where((eb) =>
       eb.or([

--- a/src/commands/kol/mrstore.test.ts
+++ b/src/commands/kol/mrstore.test.ts
@@ -2,15 +2,15 @@ import type { MrStoreItem } from "kol.js/domains/MrStore";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 const {
-  upsertIotmByName,
-  clearIotmRemovedFromStore,
-  setIotmRemovedFromStore,
-  getIotmsInStore,
+  upsertMrStoreItemByName,
+  clearMrStoreItemRemovedFromStore,
+  setMrStoreItemRemovedFromStore,
+  getMrStoreItemsInStore,
 } = vi.hoisted(() => ({
-  upsertIotmByName: vi.fn(),
-  clearIotmRemovedFromStore: vi.fn(),
-  setIotmRemovedFromStore: vi.fn(),
-  getIotmsInStore: vi.fn(),
+  upsertMrStoreItemByName: vi.fn(),
+  clearMrStoreItemRemovedFromStore: vi.fn(),
+  setMrStoreItemRemovedFromStore: vi.fn(),
+  getMrStoreItemsInStore: vi.fn(),
 }));
 
 const { alert } = vi.hoisted(() => ({ alert: vi.fn() }));
@@ -18,10 +18,10 @@ const { alert } = vi.hoisted(() => ({ alert: vi.fn() }));
 const { getCurrentItems } = vi.hoisted(() => ({ getCurrentItems: vi.fn() }));
 
 vi.mock("../../clients/database.js", () => ({
-  upsertIotmByName,
-  clearIotmRemovedFromStore,
-  setIotmRemovedFromStore,
-  getIotmsInStore,
+  upsertMrStoreItemByName,
+  clearMrStoreItemRemovedFromStore,
+  setMrStoreItemRemovedFromStore,
+  getMrStoreItemsInStore,
 }));
 
 vi.mock("../../clients/discord.js", () => ({
@@ -66,7 +66,7 @@ function item(name: string, urgency = 0): MrStoreItem {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  getIotmsInStore.mockResolvedValue([]);
+  getMrStoreItemsInStore.mockResolvedValue([]);
 });
 
 describe("checkStore", () => {
@@ -76,12 +76,12 @@ describe("checkStore", () => {
   // IotM "pasta wand loot box") was never marked as removed.
   test("a failing item does not skip removal detection for other items", async () => {
     getCurrentItems.mockResolvedValue([item("first"), item("second")]);
-    upsertIotmByName.mockImplementation(({ itemName }) => {
+    upsertMrStoreItemByName.mockImplementation(({ itemName }) => {
       if (itemName === "first") throw new Error("boom");
       return Promise.resolve();
     });
     // "departed" was tracked previously but is no longer in the store.
-    getIotmsInStore.mockResolvedValue([{ itemName: "departed" }]);
+    getMrStoreItemsInStore.mockResolvedValue([{ itemName: "departed" }]);
 
     await checkStore();
 
@@ -92,11 +92,11 @@ describe("checkStore", () => {
       expect.any(Error),
     );
     // The loop continued to the next item.
-    expect(upsertIotmByName).toHaveBeenCalledWith(
+    expect(upsertMrStoreItemByName).toHaveBeenCalledWith(
       expect.objectContaining({ itemName: "second" }),
     );
     // Crucially, the removal-detection loop still ran.
-    expect(setIotmRemovedFromStore).toHaveBeenCalledWith(
+    expect(setMrStoreItemRemovedFromStore).toHaveBeenCalledWith(
       "departed",
       new Date("2026-06-10T03:30:00Z"),
     );
@@ -104,11 +104,11 @@ describe("checkStore", () => {
 
   test("predicts removal for items leaving today", async () => {
     getCurrentItems.mockResolvedValue([item("leaving", 2)]);
-    upsertIotmByName.mockResolvedValue(undefined);
+    upsertMrStoreItemByName.mockResolvedValue(undefined);
 
     await checkStore();
 
-    expect(setIotmRemovedFromStore).toHaveBeenCalledWith(
+    expect(setMrStoreItemRemovedFromStore).toHaveBeenCalledWith(
       "leaving",
       new Date("2026-06-11T03:30:00Z"),
     );
@@ -121,8 +121,8 @@ describe("checkStore", () => {
 
     await checkStore();
 
-    expect(getIotmsInStore).not.toHaveBeenCalled();
-    expect(setIotmRemovedFromStore).not.toHaveBeenCalled();
+    expect(getMrStoreItemsInStore).not.toHaveBeenCalled();
+    expect(setMrStoreItemRemovedFromStore).not.toHaveBeenCalled();
     expect(alert).toHaveBeenCalledWith(
       "checkStore: store fetch was empty - skipping (possible rollover quirk)",
     );
@@ -132,15 +132,73 @@ describe("checkStore", () => {
     getCurrentItems.mockResolvedValue([
       { ...item("uncle buck thing"), currency: "uncle_buck" },
     ]);
-    upsertIotmByName.mockResolvedValue(undefined);
+    upsertMrStoreItemByName.mockResolvedValue(undefined);
 
     await checkStore();
 
-    expect(upsertIotmByName).toHaveBeenCalledWith(
+    expect(upsertMrStoreItemByName).toHaveBeenCalledWith(
       expect.objectContaining({
         itemName: "uncle buck thing",
         currency: "uncle_buck",
       }),
     );
+  });
+
+  test("derives category from the store category, defaulting to a monthless 'other'", async () => {
+    getCurrentItems.mockResolvedValue([item("a permanent")]);
+    upsertMrStoreItemByName.mockResolvedValue(undefined);
+
+    await checkStore();
+
+    expect(upsertMrStoreItemByName).toHaveBeenCalledWith(
+      expect.objectContaining({
+        itemName: "a permanent",
+        category: "other",
+        month: null,
+        subscriberItem: false,
+      }),
+    );
+  });
+
+  test("an item-of-the-month is a subscriber iotm with the current month", async () => {
+    getCurrentItems.mockResolvedValue([
+      {
+        ...item("monthly thing"),
+        category: "Mr. Accessory's Item-of-the-Month",
+      },
+    ]);
+    upsertMrStoreItemByName.mockResolvedValue(undefined);
+
+    await checkStore();
+
+    expect(upsertMrStoreItemByName).toHaveBeenCalledWith(
+      expect.objectContaining({
+        itemName: "monthly thing",
+        category: "iotm",
+        subscriberItem: true,
+        month: new Date("2026-06-01T00:00:00Z"),
+      }),
+    );
+  });
+
+  test("an item-of-the-year is a non-subscriber ioty dated to January", async () => {
+    getCurrentItems.mockResolvedValue([
+      {
+        ...item("yearly thing"),
+        category: "Mr. Accessory's Item-of-the-Year",
+      },
+    ]);
+    upsertMrStoreItemByName.mockResolvedValue(undefined);
+
+    await checkStore();
+
+    const arg = upsertMrStoreItemByName.mock.calls[0][0] as {
+      category: string;
+      subscriberItem: boolean;
+      month: Date;
+    };
+    expect(arg.category).toBe("ioty");
+    expect(arg.subscriberItem).toBe(false);
+    expect(arg.month.getUTCMonth()).toBe(0);
   });
 });

--- a/src/commands/kol/mrstore.ts
+++ b/src/commands/kol/mrstore.ts
@@ -2,16 +2,30 @@ import { LoathingDate } from "kol.js";
 import { MrStore, MrStoreUrgency } from "kol.js/domains/MrStore";
 
 import {
-  clearIotmRemovedFromStore,
-  getIotmsInStore,
-  setIotmRemovedFromStore,
-  upsertIotmByName,
+  clearMrStoreItemRemovedFromStore,
+  getMrStoreItemsInStore,
+  setMrStoreItemRemovedFromStore,
+  upsertMrStoreItemByName,
 } from "../../clients/database.js";
 import { discordClient } from "../../clients/discord.js";
 import { kolClient } from "../../clients/kol.js";
 import { determineIotmMonth } from "../../server/apps/oaf/routes/subs.js";
 
 const IOTM_CATEGORY_PATTERN = /^.+'s Item-of-the-Month$/;
+const IOTY_CATEGORY_PATTERN = /^.+'s Item-of-the-Year$/;
+
+function deriveCategory(category: string): "iotm" | "ioty" | "other" {
+  if (IOTM_CATEGORY_PATTERN.test(category)) return "iotm";
+  if (IOTY_CATEGORY_PATTERN.test(category)) return "ioty";
+  return "other";
+}
+
+function getMonthForCategory(category: "iotm" | "ioty" | "other"): Date | null {
+  if (category === "iotm") return determineIotmMonth();
+  if (category === "ioty")
+    return new Date(Date.UTC(new Date().getUTCFullYear(), 0, 1));
+  return null;
+}
 
 const mrStore = new MrStore(kolClient);
 
@@ -39,7 +53,6 @@ export async function checkStore() {
     }
 
     const now = LoathingDate.getRollover();
-    const month = determineIotmMonth();
 
     const currentNames = new Set<string>();
 
@@ -49,12 +62,18 @@ export async function checkStore() {
       // Isolate each item so one failure can't abort the whole run (and,
       // crucially, can't skip the removal-detection loop below).
       try {
-        const subscriberItem = IOTM_CATEGORY_PATTERN.test(item.category);
+        const category = deriveCategory(item.category);
+        const subscriberItem = category === "iotm";
 
-        await upsertIotmByName({
+        // iotms belong to a month; ioty items are always January; permanent
+        // ("other") items have no meaningful month.
+        const month = getMonthForCategory(category);
+
+        await upsertMrStoreItemByName({
           itemName: item.name,
           itemDescid: item.descid,
           itemImage: item.image,
+          category,
           month,
           mraCost: item.cost,
           currency: item.currency,
@@ -63,12 +82,12 @@ export async function checkStore() {
         });
 
         // Always clear first so stale predictions are removed, then re-predict if still leaving today
-        await clearIotmRemovedFromStore(item.name);
+        await clearMrStoreItemRemovedFromStore(item.name);
         if (item.urgency === MrStoreUrgency.Today) {
           void discordClient.alert(
             `checkStore: predicting removal of "${item.name}" at next rollover`,
           );
-          await setIotmRemovedFromStore(
+          await setMrStoreItemRemovedFromStore(
             item.name,
             LoathingDate.getNextRollover(),
           );
@@ -83,13 +102,13 @@ export async function checkStore() {
     }
 
     // Mark any previously-tracked items no longer in the store as removed
-    const inStore = await getIotmsInStore();
-    for (const iotm of inStore) {
-      if (iotm.itemName && !currentNames.has(iotm.itemName)) {
+    const inStore = await getMrStoreItemsInStore();
+    for (const storeItem of inStore) {
+      if (storeItem.itemName && !currentNames.has(storeItem.itemName)) {
         void discordClient.alert(
-          `checkStore: marking "${iotm.itemName}" as removed from store`,
+          `checkStore: marking "${storeItem.itemName}" as removed from store`,
         );
-        await setIotmRemovedFromStore(iotm.itemName, now);
+        await setMrStoreItemRemovedFromStore(storeItem.itemName, now);
       }
     }
   } catch (error) {

--- a/src/database-types.ts
+++ b/src/database-types.ts
@@ -105,14 +105,15 @@ export interface DailySubmissionTable {
   submittedAt: ColumnType<Date, Date | undefined, Date>;
 }
 
-export interface IotmTable {
+export interface MrStoreItemTable {
   id: Generated<number>;
   itemName: string | null;
   itemDescid: number | null;
   itemImage: string | null;
-  month: ColumnType<Date, Date | string, Date | string>;
+  month: ColumnType<Date | null, Date | string | null, Date | string | null>;
   mraCost: Generated<number>;
   currency: Generated<"mr_accessory" | "uncle_buck">;
+  category: "iotm" | "ioty" | "other";
   subscriberItem: Generated<boolean>;
   addedToStore: ColumnType<
     Date | null,
@@ -145,7 +146,7 @@ export interface DB {
   FlowerPriceAlert: FlowerPriceAlertTable;
   Daily: DailyTable;
   DailySubmission: DailySubmissionTable;
-  Iotm: IotmTable;
+  MrStoreItem: MrStoreItemTable;
 }
 
 export type Player = Selectable<PlayerTable>;
@@ -161,4 +162,4 @@ export type FlowerPrices = Selectable<FlowerPricesTable>;
 export type FlowerPriceAlert = Selectable<FlowerPriceAlertTable>;
 export type Daily = Selectable<DailyTable>;
 export type DailySubmission = Selectable<DailySubmissionTable>;
-export type Iotm = Selectable<IotmTable>;
+export type MrStoreItem = Selectable<MrStoreItemTable>;

--- a/src/server/apps/calendar/routes/calendar.ts
+++ b/src/server/apps/calendar/routes/calendar.ts
@@ -4,13 +4,13 @@ import { LoathingDate, toWikiLink } from "kol.js";
 import { dataOfLoathingClient } from "../../../../clients/dataOfLoathing.js";
 import {
   getDailiesForGamedayRange,
-  getIotmEventsForDateRange,
+  getMrStoreItemEventsForDateRange,
   getRafflesForGamedayRange,
 } from "../../../../clients/database.js";
 import { DAILY_GLOBALS } from "../../../../commands/misc/_globals.js";
 import type {
   CalendarData,
-  IotmEvent,
+  MrStoreItemEvent,
   TextSegment,
 } from "../web/types/calendar.js";
 
@@ -110,10 +110,10 @@ calendarRouter.get("/", async (req, res) => {
   const fromDate = new Date(epochMs + from * DAY_MS);
   const toDate = new Date(epochMs + (to + 1) * DAY_MS);
 
-  const [dailies, raffles, iotms] = await Promise.all([
+  const [dailies, raffles, mrStoreItems] = await Promise.all([
     getDailiesForGamedayRange(from, to),
     getRafflesForGamedayRange(from, to),
-    getIotmEventsForDateRange(fromDate, toDate),
+    getMrStoreItemEventsForDateRange(fromDate, toDate),
   ]);
 
   const dailyDisplayNames = new Map(
@@ -125,40 +125,40 @@ calendarRouter.get("/", async (req, res) => {
   const dateToGameday = (d: Date) =>
     Math.floor((d.getTime() - epochMs) / DAY_MS);
 
-  const iotmEvents: Record<number, IotmEvent[]> = {};
-  const pushEvent = (gameday: number, event: IotmEvent) => {
-    (iotmEvents[gameday] ??= []).push(event);
+  const mrStoreItemEvents: Record<number, MrStoreItemEvent[]> = {};
+  const pushEvent = (gameday: number, event: MrStoreItemEvent) => {
+    (mrStoreItemEvents[gameday] ??= []).push(event);
   };
 
-  for (const iotm of iotms) {
-    if (iotm.addedToStore) {
-      pushEvent(dateToGameday(iotm.addedToStore), {
-        itemName: iotm.itemName,
-        itemImage: iotm.itemImage,
+  for (const item of mrStoreItems) {
+    if (item.addedToStore) {
+      pushEvent(dateToGameday(item.addedToStore), {
+        itemName: item.itemName,
+        itemImage: item.itemImage,
         type: "added",
-        time: iotm.addedToStore.toISOString(),
+        time: item.addedToStore.toISOString(),
       });
     }
-    if (iotm.removedFromStore) {
-      pushEvent(dateToGameday(iotm.removedFromStore), {
-        itemName: iotm.itemName,
-        itemImage: iotm.itemImage,
+    if (item.removedFromStore) {
+      pushEvent(dateToGameday(item.removedFromStore), {
+        itemName: item.itemName,
+        itemImage: item.itemImage,
         type: "removed",
-        time: iotm.removedFromStore.toISOString(),
+        time: item.removedFromStore.toISOString(),
       });
     }
-    if (iotm.distributedToSubscribers) {
-      pushEvent(dateToGameday(iotm.distributedToSubscribers), {
-        itemName: iotm.itemName,
-        itemImage: iotm.itemImage,
+    if (item.distributedToSubscribers) {
+      pushEvent(dateToGameday(item.distributedToSubscribers), {
+        itemName: item.itemName,
+        itemImage: item.itemImage,
         type: "distributed",
-        time: iotm.distributedToSubscribers.toISOString(),
+        time: item.distributedToSubscribers.toISOString(),
       });
     }
   }
 
   const eventOrder = { distributed: 0, added: 1, removed: 2 };
-  for (const events of Object.values(iotmEvents)) {
+  for (const events of Object.values(mrStoreItemEvents)) {
     events.sort((a, b) => eventOrder[a.type] - eventOrder[b.type]);
   }
 
@@ -197,7 +197,7 @@ calendarRouter.get("/", async (req, res) => {
         ];
       }),
     ),
-    iotmEvents,
+    mrStoreItemEvents,
   };
 
   res.json(result);

--- a/src/server/apps/calendar/web/components/DayDetail.tsx
+++ b/src/server/apps/calendar/web/components/DayDetail.tsx
@@ -1,13 +1,13 @@
 import { LoathingDate } from "kol.js";
 import { toWikiLink } from "kol.js";
 
-import type { CalendarData, IotmEvent } from "../types/calendar.js";
+import type { CalendarData, MrStoreItemEvent } from "../types/calendar.js";
 import WardrobeSection from "./WardrobeSection.js";
 
 const MOON_ICONS = ["🌑", "🌘", "🌗", "🌖", "🌕", "🌔", "🌓", "🌒"];
 
-function iotmEventSuffix(
-  event: IotmEvent,
+function mrStoreItemEventSuffix(
+  event: MrStoreItemEvent,
   timeFormat: Intl.DateTimeFormat,
 ): string {
   switch (event.type) {
@@ -53,7 +53,7 @@ export default function DayDetail({
   );
   const rolloverTime = localTimeFormat.format(rollover);
 
-  const iotmEvents = data.iotmEvents[gameday];
+  const mrStoreItemEvents = data.mrStoreItemEvents[gameday];
 
   const DAILIES_START_GAMEDAY = 8432; // Started collecting dailies on March 13, 2026
   const isFuture = gameday > todayGameday;
@@ -116,11 +116,11 @@ export default function DayDetail({
         </div>
       )}
 
-      {iotmEvents && iotmEvents.length > 0 && (
+      {mrStoreItemEvents && mrStoreItemEvents.length > 0 && (
         <div className="day-detail-section">
           <h3>Mr. Store</h3>
           <ul>
-            {iotmEvents.map((e, i) => (
+            {mrStoreItemEvents.map((e, i) => (
               <li key={i}>
                 {e.itemName ? (
                   <a
@@ -133,7 +133,7 @@ export default function DayDetail({
                 ) : (
                   "Unknown item"
                 )}
-                {iotmEventSuffix(e, localTimeFormat)}
+                {mrStoreItemEventSuffix(e, localTimeFormat)}
               </li>
             ))}
           </ul>

--- a/src/server/apps/calendar/web/components/GregorianCalendar.tsx
+++ b/src/server/apps/calendar/web/components/GregorianCalendar.tsx
@@ -1,6 +1,6 @@
 import { LoathingDate } from "kol.js";
 
-import type { IotmEvent } from "../types/calendar.js";
+import type { MrStoreItemEvent } from "../types/calendar.js";
 import { BouncingEmoji } from "./BouncingEmoji.js";
 import CalendarNav from "./CalendarNav.js";
 import { getDayEvents } from "./eventEmoji.js";
@@ -29,7 +29,7 @@ type Props = {
   onJump: (year: number, month: number) => void;
   onJumpToToday: () => void;
   moonlightMode: boolean;
-  iotmEvents: Record<number, IotmEvent[]>;
+  mrStoreItemEvents: Record<number, MrStoreItemEvent[]>;
 };
 
 function getGridDates(year: number, month: number) {
@@ -65,7 +65,7 @@ export default function GregorianCalendar({
   onJump,
   onJumpToToday,
   moonlightMode,
-  iotmEvents,
+  mrStoreItemEvents,
 }: Props) {
   const dates = getGridDates(year, month);
 
@@ -100,7 +100,7 @@ export default function GregorianCalendar({
               ld?.getHolidays().filter((h) => h !== statDay) ?? [];
             const events = getDayEvents(
               holidays,
-              preEpoch ? undefined : iotmEvents[gameday],
+              preEpoch ? undefined : mrStoreItemEvents[gameday],
             );
 
             const classes = [

--- a/src/server/apps/calendar/web/components/KolCalendar.tsx
+++ b/src/server/apps/calendar/web/components/KolCalendar.tsx
@@ -1,7 +1,7 @@
 import { LoathingDate } from "kol.js";
 import React from "react";
 
-import type { IotmEvent } from "../types/calendar.js";
+import type { MrStoreItemEvent } from "../types/calendar.js";
 import { BouncingEmoji } from "./BouncingEmoji.js";
 import CalendarNav from "./CalendarNav.js";
 import { getDayEvents } from "./eventEmoji.js";
@@ -36,7 +36,7 @@ type Props = {
   onJump: (kolYear: number) => void;
   onJumpToToday: () => void;
   moonlightMode: boolean;
-  iotmEvents: Record<number, IotmEvent[]>;
+  mrStoreItemEvents: Record<number, MrStoreItemEvent[]>;
 };
 
 export default function KolCalendar({
@@ -48,7 +48,7 @@ export default function KolCalendar({
   onJump,
   onJumpToToday,
   moonlightMode,
-  iotmEvents,
+  mrStoreItemEvents,
 }: Props) {
   return (
     <div>
@@ -83,7 +83,7 @@ export default function KolCalendar({
                 const holidays = ld
                   .getHolidays()
                   .filter((h) => h !== statDay);
-                const events = getDayEvents(holidays, iotmEvents[gameday]);
+                const events = getDayEvents(holidays, mrStoreItemEvents[gameday]);
 
                 const classes = [
                   "calendar-cell",

--- a/src/server/apps/calendar/web/components/eventEmoji.ts
+++ b/src/server/apps/calendar/web/components/eventEmoji.ts
@@ -1,4 +1,4 @@
-import type { IotmEvent } from "../types/calendar.js";
+import type { MrStoreItemEvent } from "../types/calendar.js";
 
 export const HOLIDAY_EMOJI: Record<string, string> = {
   "Festival of Jarlsberg": "🪄",
@@ -22,13 +22,13 @@ export const HOLIDAY_EMOJI: Record<string, string> = {
   "The Comet": "☄️",
 };
 
-const IOTM_EVENT_EMOJI: Record<IotmEvent["type"], string> = {
+const MR_STORE_EVENT_EMOJI: Record<MrStoreItemEvent["type"], string> = {
   distributed: "📬",
   added: "🙂",
   removed: "🙁",
 };
 
-const IOTM_EVENT_VERB: Record<IotmEvent["type"], string> = {
+const MR_STORE_EVENT_VERB: Record<MrStoreItemEvent["type"], string> = {
   distributed: "distributed to subscribers",
   added: "entered Mr. Store",
   removed: "left Mr. Store",
@@ -38,13 +38,13 @@ export type DayEvent = { emoji: string; label: string };
 
 export function getDayEvents(
   holidays: string[],
-  iotmEvents: IotmEvent[] = [],
+  mrStoreItemEvents: MrStoreItemEvent[] = [],
 ): DayEvent[] {
   return [
     ...holidays.map((h) => ({ emoji: HOLIDAY_EMOJI[h] ?? "🎉", label: h })),
-    ...iotmEvents.map((e) => ({
-      emoji: IOTM_EVENT_EMOJI[e.type],
-      label: `${e.itemName ?? "Unknown item"} ${IOTM_EVENT_VERB[e.type]}`,
+    ...mrStoreItemEvents.map((e) => ({
+      emoji: MR_STORE_EVENT_EMOJI[e.type],
+      label: `${e.itemName ?? "Unknown item"} ${MR_STORE_EVENT_VERB[e.type]}`,
     })),
   ];
 }

--- a/src/server/apps/calendar/web/pages/CalendarPage.tsx
+++ b/src/server/apps/calendar/web/pages/CalendarPage.tsx
@@ -86,7 +86,7 @@ export default function CalendarPage() {
     return () => document.body.classList.remove("moonlight-mode");
   }, [moonlightMode]);
 
-  const [data, setData] = useState<CalendarData>({ dailies: {}, raffles: {}, iotmEvents: {} });
+  const [data, setData] = useState<CalendarData>({ dailies: {}, raffles: {}, mrStoreItemEvents: {} });
   const [loading, setLoading] = useState(false);
 
   const range = useMemo(
@@ -102,7 +102,7 @@ export default function CalendarPage() {
     fetch(`/api/calendar?from=${range.from}&to=${range.to}`)
       .then((r) => r.json() as Promise<CalendarData>)
       .then(setData)
-      .catch(() => setData({ dailies: {}, raffles: {}, iotmEvents: {} }))
+      .catch(() => setData({ dailies: {}, raffles: {}, mrStoreItemEvents: {} }))
       .finally(() => setLoading(false));
   }, [range.from, range.to]);
 
@@ -203,7 +203,7 @@ export default function CalendarPage() {
           onJump={jumpGregorian}
           onJumpToToday={jumpToToday}
           moonlightMode={moonlightMode}
-          iotmEvents={data.iotmEvents}
+          mrStoreItemEvents={data.mrStoreItemEvents}
         />
       ) : (
         <KolCalendar
@@ -215,7 +215,7 @@ export default function CalendarPage() {
           onJump={jumpKol}
           onJumpToToday={jumpToToday}
           moonlightMode={moonlightMode}
-          iotmEvents={data.iotmEvents}
+          mrStoreItemEvents={data.mrStoreItemEvents}
         />
       )}
 

--- a/src/server/apps/calendar/web/types/calendar.ts
+++ b/src/server/apps/calendar/web/types/calendar.ts
@@ -19,7 +19,7 @@ export type RaffleInfo = {
   }[];
 };
 
-export type IotmEvent = {
+export type MrStoreItemEvent = {
   itemName: string | null;
   itemImage: string | null;
   type: "added" | "removed" | "distributed";
@@ -29,5 +29,5 @@ export type IotmEvent = {
 export type CalendarData = {
   dailies: Record<number, DailyInfo[]>;
   raffles: Record<number, RaffleInfo>;
-  iotmEvents: Record<number, IotmEvent[]>;
+  mrStoreItemEvents: Record<number, MrStoreItemEvent[]>;
 };


### PR DESCRIPTION
## What

The `Iotm` table has outgrown its name — it now tracks **every** Mr. Store item, not just items-of-the-month (permanent fixtures like Mr. Accessories, the name change form, Monster Manuel; annual Items-of-the-Year; and monthly IotMs). This renames it to `MrStoreItem` and gives it a proper `category`.

## Changes

- **Migration** (`1781280001000_mr_store_item.ts`): renames `Iotm` → `MrStoreItem` (table, sequence, pkey, unique index, currency constraint); adds `category` (`iotm` | `ioty` | `other`, `NOT NULL` + CHECK); makes `month` nullable and nulls it for `other`. Backfill: generic `iotm`/`other` from `subscriberItem`, then reclassify the 4 IoTY rows by name (runs before the month-null step so they keep their January months; no-ops on a fresh DB since those rows are prod-only). `down()` reverses it (lossy — documented in-file).
- **`category` is orthogonal to `subscriberItem`** — a month can have two `iotm` items where only one goes to subscribers (e.g. Oct 2024: Boxed Bat Wings went to subscribers, photo booth sized crate did not), so the boolean stays.
- **`month` semantics**: `null` for permanent `other` items; the current month for `iotm`; always January for `ioty`.
- **`checkStore`** derives `category` from the Mr. Store category string and sets `month` per category.
- **Rename boundary**: the table and its data-access plumbing are renamed (incl. the calendar `IotmEvent` → `MrStoreItemEvent` wire type/key). The genuine Item-of-the-Month concept is left alone: `determineIotmMonth`/`formatIotmMonth`, the subscriber farming threads, the `itom.ts` joke, `iotmChannel`, and `exchange.ts`'s external `iotm_*` API fields.

## Follow-up (after deploy)

One prod-only historical correction remains manual (the `category` column doesn't exist in prod until the migration runs): inserting the missing Oct 2024 non-subscriber IotM (`photo booth sized crate`). The IoTY reclassification is handled by the migration.

## Verification

typecheck, lint, 149 tests, frontend build; against a throwaway Postgres: migration up→down→up reversibility, the IoTY reclassify path, and the live-DB integration regression tests (42P10 partial index, addedToStore preservation).