### PR TITLE
Time out verified users in the autoban channel instead of banning

### DIFF
--- a/src/commands/misc/banme.ts
+++ b/src/commands/misc/banme.ts
@@ -1,37 +1,65 @@
-import { Events, Message, blockQuote } from "discord.js";
+import { Events, GuildMember, Message, blockQuote } from "discord.js";
 
 import { discordClient } from "../../clients/discord.js";
 import { config } from "../../config.js";
+
+// Discord caps communication timeouts at 28 days.
+const VERIFIED_TIMEOUT_MS = 28 * 24 * 60 * 60 * 1000;
+
+async function timeoutVerified(member: GuildMember, message: Message) {
+  if (!member.moderatable) {
+    await discordClient.alert(
+      `Tried to time out ${member.user.tag} for posting in the autoban channel, but I couldn't.`,
+    );
+    return;
+  }
+
+  await member.timeout(VERIFIED_TIMEOUT_MS, "Posted in the autoban channel");
+  await message.delete();
+
+  await discordClient.alert(
+    `Timed out ${member.user.tag} for 28 days for posting in the autoban channel.\n\n${blockQuote(message.content)}`,
+  );
+}
+
+async function banUnverified(member: GuildMember, message: Message) {
+  if (!member.bannable) {
+    await discordClient.alert(
+      `Tried to ban ${member.user.tag} for posting in the autoban channel, but I couldn't ban them.`,
+    );
+    return;
+  }
+
+  const joinDate = member.joinedAt;
+  const banDate = new Date();
+
+  await member.ban({ reason: "Posted in the autoban channel" });
+  await message.delete();
+
+  if (message.channel.isSendable()) {
+    await message.channel.send(
+      `🪦 ${member.user.username} ${joinDate?.getFullYear() ?? "????"} - ${banDate.getFullYear()}`,
+    );
+  }
+
+  await discordClient.alert(
+    `Banned ${member.user.tag} for posting in the autoban channel.\n\n${blockQuote(message.content)}`,
+  );
+}
 
 async function onMessage(message: Message) {
   if (message.author.id === discordClient.user?.id) return;
   const member = message.member;
   if (!member) return;
 
-  if (message.channelId === config.BAN_ME_CHANNEL_ID) {
-    if (!member.bannable) {
-      await discordClient.alert(
-        `Tried to ban ${member.user.tag} for posting in the autoban channel, but I couldn't ban them.`,
-      );
-      return;
-    }
+  if (message.channelId !== config.BAN_ME_CHANNEL_ID) return;
 
-    const joinDate = member.joinedAt;
-    const banDate = new Date();
-
-    await member.ban({ reason: "Posted in the autoban channel" });
-    await message.delete();
-
-    if (message.channel.isSendable()) {
-      await message.channel.send(
-        `🪦 ${member.user.username} ${joinDate?.getFullYear() ?? "????"} - ${banDate.getFullYear()}`,
-      );
-    }
-
-    await discordClient.alert(
-      `Banned ${member.user.tag} for posting in the autoban channel.\n\n${blockQuote(message.content)}`,
-    );
+  if (member.roles.cache.has(config.VERIFIED_ROLE_ID)) {
+    await timeoutVerified(member, message);
+    return;
   }
+
+  await banUnverified(member, message);
 }
 
 export function init() {


### PR DESCRIPTION
## What

If a **verified** user posts in the autoban channel, they now receive a 28-day timeout instead of a permanent ban. Their post is still instantly deleted, but no tombstone message is posted.

Unverified posters keep the existing behaviour: ban + delete + tombstone.

| Poster | Action | Tombstone? |
|--------|--------|------------|
| Unverified | Ban + delete post | Yes |
| Verified | 28-day timeout + delete post | No |

## Notes

- Verification is detected via the synced `VERIFIED_ROLE_ID` role, which is kept in sync with the database.
- 28 days is Discord's maximum communication timeout — the API rejects anything longer.