### PR TITLE
Degrade gracefully when data-of-loathing is unavailable

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "convert-svg-to-png": "^0.7.1",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.6",
-    "data-of-loathing": "4.3.0",
+    "data-of-loathing": "4.3.1",
     "date-fns": "^4.1.0",
     "discord.js": "^14.25.1",
     "entities": "^7.0.1",

--- a/src/clients/dataOfLoathing.test.ts
+++ b/src/clients/dataOfLoathing.test.ts
@@ -36,7 +36,7 @@ describe("Degraded mode", () => {
   test("load() does not throw when data source is unavailable", async () => {
     vi.mocked(createClient).mockReturnValueOnce({
       load: vi.fn().mockRejectedValue(new Error("network error")),
-    } as ReturnType<typeof createClient>);
+    } as unknown as ReturnType<typeof createClient>);
 
     const client = new DataOfLoathingClient();
     await expect(client.load()).resolves.toBeUndefined();
@@ -45,7 +45,7 @@ describe("Degraded mode", () => {
   test("loaded is false after a failed load", async () => {
     vi.mocked(createClient).mockReturnValueOnce({
       load: vi.fn().mockRejectedValue(new Error("network error")),
-    } as ReturnType<typeof createClient>);
+    } as unknown as ReturnType<typeof createClient>);
 
     const client = new DataOfLoathingClient();
     await client.load();
@@ -58,7 +58,7 @@ describe("Degraded mode", () => {
       get query() {
         return { find: vi.fn().mockResolvedValue([]) };
       },
-    } as ReturnType<typeof createClient>);
+    } as unknown as ReturnType<typeof createClient>);
 
     const client = new DataOfLoathingClient();
     await client.load();
@@ -69,7 +69,7 @@ describe("Degraded mode", () => {
     const mockLoad = vi.fn().mockRejectedValue(new Error("network error"));
     vi.mocked(createClient).mockReturnValueOnce({
       load: mockLoad,
-    } as ReturnType<typeof createClient>);
+    } as unknown as ReturnType<typeof createClient>);
 
     const client = new DataOfLoathingClient();
     await client.load();

--- a/src/clients/dataOfLoathing.test.ts
+++ b/src/clients/dataOfLoathing.test.ts
@@ -1,9 +1,17 @@
-import { Monster as DolMonster } from "data-of-loathing";
-import { beforeAll, describe, expect, test } from "vitest";
+import { Monster as DolMonster, createClient } from "data-of-loathing";
+import { beforeAll, describe, expect, test, vi } from "vitest";
 
 import { testDb } from "../__fixtures__/testDb.js";
 import { Monster } from "../things/Monster.js";
-import { dataOfLoathingClient } from "./dataOfLoathing.js";
+import {
+  DataOfLoathingClient,
+  dataOfLoathingClient,
+} from "./dataOfLoathing.js";
+
+vi.mock("data-of-loathing", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("data-of-loathing")>();
+  return { ...actual, createClient: vi.fn(actual.createClient) };
+});
 
 let hermit: Monster;
 
@@ -21,5 +29,52 @@ describe("Wiki link", () => {
   test("Hermit", () => {
     const link = dataOfLoathingClient.getWikiLink(hermit);
     expect(link).toBe("https://wiki.kingdomofloathing.com/Monster:1781");
+  });
+});
+
+describe("Degraded mode", () => {
+  test("load() does not throw when data source is unavailable", async () => {
+    vi.mocked(createClient).mockReturnValueOnce({
+      load: vi.fn().mockRejectedValue(new Error("network error")),
+    } as ReturnType<typeof createClient>);
+
+    const client = new DataOfLoathingClient();
+    await expect(client.load()).resolves.toBeUndefined();
+  });
+
+  test("loaded is false after a failed load", async () => {
+    vi.mocked(createClient).mockReturnValueOnce({
+      load: vi.fn().mockRejectedValue(new Error("network error")),
+    } as ReturnType<typeof createClient>);
+
+    const client = new DataOfLoathingClient();
+    await client.load();
+    expect(client.loaded).toBe(false);
+  });
+
+  test("loaded is true after a successful load", async () => {
+    vi.mocked(createClient).mockReturnValueOnce({
+      load: vi.fn().mockResolvedValue(undefined),
+      get query() {
+        return { find: vi.fn().mockResolvedValue([]) };
+      },
+    } as ReturnType<typeof createClient>);
+
+    const client = new DataOfLoathingClient();
+    await client.load();
+    expect(client.loaded).toBe(true);
+  });
+
+  test("reload() does not retry within an hour after a failed load", async () => {
+    const mockLoad = vi.fn().mockRejectedValue(new Error("network error"));
+    vi.mocked(createClient).mockReturnValueOnce({
+      load: mockLoad,
+    } as ReturnType<typeof createClient>);
+
+    const client = new DataOfLoathingClient();
+    await client.load();
+    const result = await client.reload();
+    expect(result).toBe(false);
+    expect(mockLoad).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/clients/dataOfLoathing.test.ts
+++ b/src/clients/dataOfLoathing.test.ts
@@ -34,18 +34,18 @@ describe("Wiki link", () => {
 
 describe("Degraded mode", () => {
   test("load() does not throw when data source is unavailable", async () => {
-    vi.mocked(createClient).mockReturnValueOnce({
-      load: vi.fn().mockRejectedValue(new Error("network error")),
-    } as unknown as ReturnType<typeof createClient>);
+    const mockClient = createClient();
+    vi.spyOn(mockClient, "load").mockRejectedValue(new Error("network error"));
+    vi.mocked(createClient).mockReturnValueOnce(mockClient);
 
     const client = new DataOfLoathingClient();
     await expect(client.load()).resolves.toBeUndefined();
   });
 
   test("loaded is false after a failed load", async () => {
-    vi.mocked(createClient).mockReturnValueOnce({
-      load: vi.fn().mockRejectedValue(new Error("network error")),
-    } as unknown as ReturnType<typeof createClient>);
+    const mockClient = createClient();
+    vi.spyOn(mockClient, "load").mockRejectedValue(new Error("network error"));
+    vi.mocked(createClient).mockReturnValueOnce(mockClient);
 
     const client = new DataOfLoathingClient();
     await client.load();
@@ -53,12 +53,8 @@ describe("Degraded mode", () => {
   });
 
   test("loaded is true after a successful load", async () => {
-    vi.mocked(createClient).mockReturnValueOnce({
-      load: vi.fn().mockResolvedValue(undefined),
-      get query() {
-        return { find: vi.fn().mockResolvedValue([]) };
-      },
-    } as unknown as ReturnType<typeof createClient>);
+    const realClient = await testDb;
+    vi.mocked(createClient).mockReturnValueOnce(realClient);
 
     const client = new DataOfLoathingClient();
     await client.load();
@@ -66,10 +62,11 @@ describe("Degraded mode", () => {
   });
 
   test("reload() does not retry within an hour after a failed load", async () => {
-    const mockLoad = vi.fn().mockRejectedValue(new Error("network error"));
-    vi.mocked(createClient).mockReturnValueOnce({
-      load: mockLoad,
-    } as unknown as ReturnType<typeof createClient>);
+    const mockClient = createClient();
+    const mockLoad = vi
+      .spyOn(mockClient, "load")
+      .mockRejectedValue(new Error("network error"));
+    vi.mocked(createClient).mockReturnValueOnce(mockClient);
 
     const client = new DataOfLoathingClient();
     await client.load();

--- a/src/clients/dataOfLoathing.test.ts
+++ b/src/clients/dataOfLoathing.test.ts
@@ -59,7 +59,7 @@ describe("Degraded mode", () => {
     const client = new DataOfLoathingClient();
     await client.load();
     expect(client.loaded).toBe(true);
-  });
+  }, 15000);
 
   test("reload() does not retry within an hour after a failed load", async () => {
     const mockClient = createClient();

--- a/src/clients/dataOfLoathing.ts
+++ b/src/clients/dataOfLoathing.ts
@@ -24,6 +24,11 @@ import { wikiClient } from "./wiki.js";
 
 export class DataOfLoathingClient {
   #client = createClient();
+  #loaded = false;
+
+  get loaded() {
+    return this.#loaded;
+  }
 
   private itemByName: Map<string, Item> = new Map();
   private itemById: Map<number, Item> = new Map();
@@ -106,81 +111,90 @@ export class DataOfLoathingClient {
   }
 
   async load() {
-    await this.#client.load();
-    const em = this.#client.query;
+    try {
+      await this.#client.load();
+      const em = this.#client.query;
 
-    const skills = await em.find(DolSkill, {}, { populate: ["modifiers"] });
-    for (const s of skills) {
-      const skill = new Skill(s);
-      this.register(skill);
-      const block = skill.block();
-      if (!this.#lastSkills[block] || skill.id > this.#lastSkills[block]) {
-        this.#lastSkills[block] = skill.id;
+      const skills = await em.find(DolSkill, {}, { populate: ["modifiers"] });
+      for (const s of skills) {
+        const skill = new Skill(s);
+        this.register(skill);
+        const block = skill.block();
+        if (!this.#lastSkills[block] || skill.id > this.#lastSkills[block]) {
+          this.#lastSkills[block] = skill.id;
+        }
       }
+
+      const effects = await em.find(DolEffect, {}, { populate: ["modifiers"] });
+      for (const e of effects) {
+        this.register(new Effect(e));
+      }
+
+      const monsters = await em.find(
+        DolMonster,
+        {},
+        { populate: ["drops.item"] },
+      );
+      for (const m of monsters) {
+        this.register(new Monster(m));
+      }
+
+      const familiars = await em.find(
+        DolFamiliar,
+        {},
+        {
+          populate: [
+            "larva.modifiers",
+            "larva.consumable",
+            "larva.equipment",
+            "equipment.modifiers",
+            "equipment.consumable",
+            "equipment.equipment",
+            "modifiers",
+          ],
+        },
+      );
+      for (const f of familiars) {
+        const familiar = new Familiar(f);
+        this.register(familiar);
+        if (familiar.id > this.#lastFamiliar) this.#lastFamiliar = familiar.id;
+      }
+
+      const items = await em.find(
+        DolItem,
+        {},
+        {
+          populate: [
+            "modifiers",
+            "consumable",
+            "equipment",
+            "foldGroups.items",
+            "zapGroups.items",
+          ],
+        },
+      );
+      for (const i of items) {
+        const item = new Item(i);
+        this.register(item);
+        if (item.id > this.#lastItem) this.#lastItem = item.id;
+      }
+
+      // Wire up familiar hatchling/equipment descriptions
+      for (const familiar of this.familiars) {
+        if (familiar.hatchling) familiar.hatchling.addGrowingFamiliar(familiar);
+        if (familiar.familiarEquipment)
+          familiar.familiarEquipment.addEquppingFamiliar(familiar);
+      }
+
+      pizzaTree.build(this.effectByName);
+      this.#loaded = true;
+    } catch (e) {
+      console.warn(
+        "data-of-loathing unavailable, running in degraded mode:",
+        e,
+      );
     }
 
-    const effects = await em.find(DolEffect, {}, { populate: ["modifiers"] });
-    for (const e of effects) {
-      this.register(new Effect(e));
-    }
-
-    const monsters = await em.find(
-      DolMonster,
-      {},
-      { populate: ["drops.item"] },
-    );
-    for (const m of monsters) {
-      this.register(new Monster(m));
-    }
-
-    const familiars = await em.find(
-      DolFamiliar,
-      {},
-      {
-        populate: [
-          "larva.modifiers",
-          "larva.consumable",
-          "larva.equipment",
-          "equipment.modifiers",
-          "equipment.consumable",
-          "equipment.equipment",
-          "modifiers",
-        ],
-      },
-    );
-    for (const f of familiars) {
-      const familiar = new Familiar(f);
-      this.register(familiar);
-      if (familiar.id > this.#lastFamiliar) this.#lastFamiliar = familiar.id;
-    }
-
-    const items = await em.find(
-      DolItem,
-      {},
-      {
-        populate: [
-          "modifiers",
-          "consumable",
-          "equipment",
-          "foldGroups.items",
-          "zapGroups.items",
-        ],
-      },
-    );
-    for (const i of items) {
-      const item = new Item(i);
-      this.register(item);
-      if (item.id > this.#lastItem) this.#lastItem = item.id;
-    }
-
-    // Wire up familiar hatchling/equipment descriptions
-    for (const familiar of this.familiars) {
-      if (familiar.hatchling) familiar.hatchling.addGrowingFamiliar(familiar);
-      if (familiar.familiarEquipment)
-        familiar.familiarEquipment.addEquppingFamiliar(familiar);
-    }
-
-    pizzaTree.build(this.effectByName);
     this.lastDownloadTime = Date.now();
   }
 
@@ -188,6 +202,7 @@ export class DataOfLoathingClient {
     if (this.lastDownloadTime < Date.now() - 3600000) {
       this.clearMaps();
       clearMemoized(["things"]);
+      this.#loaded = false;
       await this.load();
       return true;
     }

--- a/src/clients/pizza.test.ts
+++ b/src/clients/pizza.test.ts
@@ -1,0 +1,68 @@
+import { Effect as DolEffect } from "data-of-loathing";
+import { beforeAll, describe, expect, test } from "vitest";
+
+import { testDb } from "../__fixtures__/testDb.js";
+import { Effect } from "../things/Effect.js";
+import { PizzaTree } from "./pizza.js";
+
+let hookahEffect: Effect;
+let avatarEffect: Effect;
+
+beforeAll(async () => {
+  const client = await testDb;
+  const em = client.query;
+  // Effect 23: hookah-eligible
+  hookahEffect = new Effect(
+    (await em.findOne(DolEffect, { id: 23 }, { populate: ["modifiers"] }))!,
+  );
+  // Effect 1888: avatar (hookah-ineligible)
+  avatarEffect = new Effect(
+    (await em.findOne(DolEffect, { id: 1888 }, { populate: ["modifiers"] }))!,
+  );
+});
+
+describe("PizzaTree degraded mode (empty data)", () => {
+  test("findPizzas returns no options when tree is empty", () => {
+    const tree = new PizzaTree();
+    tree.build(new Map());
+    const [options] = tree.findPizzas("past");
+    expect(options).toHaveLength(0);
+  });
+
+  test("findPizzas returns no options for any input when tree is empty", () => {
+    const tree = new PizzaTree();
+    tree.build(new Map());
+    const [options] = tree.findPizzas("a");
+    expect(options).toHaveLength(0);
+  });
+});
+
+describe("PizzaTree with data", () => {
+  test("hookah-eligible effect is reachable by its first letter", () => {
+    const tree = new PizzaTree();
+    tree.build(new Map([[hookahEffect.name.toLowerCase(), hookahEffect]]));
+    const firstLetter = hookahEffect.name.toLowerCase().charAt(0);
+    const [options] = tree.findPizzas(firstLetter);
+    expect(options).toContain(hookahEffect);
+  });
+
+  test("avatar (hookah-ineligible) effect is never added to the tree", () => {
+    const tree = new PizzaTree();
+    tree.build(
+      new Map([
+        [hookahEffect.name.toLowerCase(), hookahEffect],
+        [avatarEffect.name.toLowerCase(), avatarEffect],
+      ]),
+    );
+    const [allOptions] = tree.findPizzas("");
+    expect(allOptions).toContain(hookahEffect);
+    expect(allOptions).not.toContain(avatarEffect);
+  });
+
+  test("precalculate sets pizza metadata on effects", () => {
+    const tree = new PizzaTree();
+    tree.build(new Map([[hookahEffect.name.toLowerCase(), hookahEffect]]));
+    // Uncontested effect needs no disambiguating letters
+    expect(hookahEffect.pizza).toEqual({ letters: "", options: 1 });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,7 +98,14 @@ async function main() {
 
   console.log("Downloading data of loathing");
   await dataOfLoathingClient.load();
-  console.log("All data of loathing downloaded.");
+  if (dataOfLoathingClient.loaded) {
+    console.log("All data of loathing downloaded.");
+  } else {
+    console.warn("data-of-loathing unavailable, starting in degraded mode.");
+    await discordClient.alert(
+      "Started in degraded mode: data-of-loathing unavailable. Item/monster lookups will not work until the next successful reload.",
+    );
+  }
 
   console.log("Loading commands and syncing relevant data");
   await loadSlashCommands();

--- a/yarn.lock
+++ b/yarn.lock
@@ -3198,9 +3198,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"data-of-loathing@npm:4.3.0":
-  version: 4.3.0
-  resolution: "data-of-loathing@npm:4.3.0"
+"data-of-loathing@npm:4.3.1":
+  version: 4.3.1
+  resolution: "data-of-loathing@npm:4.3.1"
   dependencies:
     "@mikro-orm/core": "npm:^7.0.14"
     "@mikro-orm/sql": "npm:^7.0.14"
@@ -3215,7 +3215,7 @@ __metadata:
       optional: true
     vite-plugin-node-polyfills:
       optional: true
-  checksum: 10c0/759be048afcb4c24dae23243e3601796853f1f37ec6337222b4dfe673c7ec3e16ce6fa6a38aef427c771f77d320266db44f1e957e5ada79145a1950f9ae64d98
+  checksum: 10c0/c94c81eadf69547987a715002980f72f0a774f57618d0b0db649b4d3981826339ead7084e905872d1a3b595d126b82587176d64f4da088473c36a60fa281661e
   languageName: node
   linkType: hard
 
@@ -5483,7 +5483,7 @@ __metadata:
     convert-svg-to-png: "npm:^0.7.1"
     cookie-parser: "npm:^1.4.7"
     cors: "npm:^2.8.6"
-    data-of-loathing: "npm:4.3.0"
+    data-of-loathing: "npm:4.3.1"
     date-fns: "npm:^4.1.0"
     discord.js: "npm:^14.25.1"
     entities: "npm:^7.0.1"


### PR DESCRIPTION
## Summary

- Bumps `data-of-loathing` to 4.3.1, which falls back to a cached local SQLite database when the remote server is unreachable (previously would throw immediately on any network error)
- Wraps `DataOfLoathingClient.load()` in a try/catch so a total load failure (first boot, no cache, server down) no longer crashes the bot — it starts in degraded mode with empty maps, which existing callers already handle gracefully via null checks
- `lastDownloadTime` is now updated unconditionally so a failed reload doesn't trigger a retry on every subsequent request
- Sends a Discord alert via `discordClient.alert()` if the bot starts in degraded mode

## Tests

- `DataOfLoathingClient`: load doesn't throw on failure, `loaded` flag reflects success/failure, `reload()` doesn't retry within an hour after a failure
- `PizzaTree`: returns empty results when built with no data (degraded mode), correctly indexes hookah-eligible effects and excludes avatar effects, `precalculate` sets the right pizza metadata