### PR TITLE
Store PvP season startDate as TIMESTAMPTZ at rollover time

### DIFF
--- a/migrations/1782864001000_pvp_season_rollover_time.ts
+++ b/migrations/1782864001000_pvp_season_rollover_time.ts
@@ -1,0 +1,9 @@
+import { type Kysely, sql } from "kysely";
+
+export async function up(db: Kysely<never>): Promise<void> {
+  await sql`
+    ALTER TABLE "PvpSeason"
+    ALTER COLUMN "startDate" TYPE TIMESTAMPTZ
+    USING ("startDate"::timestamp + interval '3 hours 30 minutes')
+  `.execute(db);
+}

--- a/src/commands/kol/pvp.ts
+++ b/src/commands/kol/pvp.ts
@@ -29,10 +29,7 @@ export function init() {
 
         const pvp = new Pvp(kolClient);
         const { seasonNumber, seasonName } = await pvp.getCurrentSeason();
-        const startDate = new Date(
-          Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1),
-        );
-        await upsertPvpSeason({ seasonNumber, seasonName, startDate });
+        await upsertPvpSeason({ seasonNumber, seasonName, startDate: now });
       } catch (error) {
         await discordClient.alert(
           "Failed to sync PvP season",

--- a/src/database-types.ts
+++ b/src/database-types.ts
@@ -135,7 +135,7 @@ export interface MrStoreItemTable {
 export interface PvpSeasonTable {
   seasonNumber: number;
   seasonName: string;
-  startDate: ColumnType<Date, Date | string, Date | string>;
+  startDate: ColumnType<Date, Date | string, Date | string>; // TIMESTAMPTZ, always at rollover time (03:30 UTC)
 }
 
 export interface DB {

--- a/src/database-types.ts
+++ b/src/database-types.ts
@@ -135,7 +135,7 @@ export interface MrStoreItemTable {
 export interface PvpSeasonTable {
   seasonNumber: number;
   seasonName: string;
-  startDate: ColumnType<Date, Date | string, Date | string>; // TIMESTAMPTZ, always at rollover time (03:30 UTC)
+  startDate: ColumnType<Date, Date | string, Date | string>;
 }
 
 export interface DB {

--- a/src/server/apps/calendar/routes/calendar.ts
+++ b/src/server/apps/calendar/routes/calendar.ts
@@ -91,6 +91,11 @@ function renderDaily(key: string, value: string): TextSegment[] {
   }
 }
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+const EPOCH_MS = LoathingDate.EPOCH.getTime();
+const dateToGameday = (d: Date) =>
+  Math.floor((d.getTime() - EPOCH_MS) / DAY_MS);
+
 export const calendarRouter = Router();
 
 calendarRouter.get("/", async (req, res) => {
@@ -107,10 +112,8 @@ calendarRouter.get("/", async (req, res) => {
     return;
   }
 
-  const DAY_MS = 24 * 60 * 60 * 1000;
-  const epochMs = LoathingDate.EPOCH.getTime();
-  const fromDate = new Date(epochMs + from * DAY_MS);
-  const toDate = new Date(epochMs + (to + 1) * DAY_MS);
+  const fromDate = new Date(EPOCH_MS + from * DAY_MS);
+  const toDate = new Date(EPOCH_MS + (to + 1) * DAY_MS);
 
   const [dailies, raffles, mrStoreItems, pvpSeasonRows] = await Promise.all([
     getDailiesForGamedayRange(from, to),
@@ -124,9 +127,6 @@ calendarRouter.get("/", async (req, res) => {
   );
 
   const dailiesByGameday = Map.groupBy(dailies, (d) => d.gameday);
-
-  const dateToGameday = (d: Date) =>
-    Math.floor((d.getTime() - epochMs) / DAY_MS);
 
   const mrStoreItemEvents: Record<number, MrStoreItemEvent[]> = {};
   const pushEvent = (gameday: number, event: MrStoreItemEvent) => {


### PR DESCRIPTION
## Summary

- Adds a migration to cast the `PvpSeason.startDate` column from `DATE` to `TIMESTAMPTZ`, shifting existing values by +3h30m to land at KoL rollover time
- Stores future seasons with the actual rollover timestamp (using `now` in the rollover handler) rather than midnight UTC
- Simplifies the calendar route — no offset arithmetic needed since timestamps are now correct by construction
- Fixes seasons appearing one day early in the calendar

## Test plan

- [ ] Run migration — `startDate` for all existing seasons should read as `03:30:00+00` on the 1st of their month
- [ ] Navigate to a season start month in the calendar — ⚔️ should appear on the correct day (not the day before)