### PR TITLE
Announce Time-Twitching Tower joust odds and winners

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,3 +52,6 @@ WHITELIST_ROLE_IDS= # comma separated role ids
 
 # /raffle
 RAFFLE_CHANNEL_ID=
+
+# Jousting (Time-Twitching Tower)
+JOUST_CHANNEL_ID=

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "http-status-codes": "^2.3.0",
     "js-sha256": "^0.11.1",
     "jsonwebtoken": "^9.0.3",
-    "kol.js": "^0.11.0",
+    "kol.js": "^0.13.0",
     "kysely": "^0.28.11",
     "lightstreamer-client-node": "^9.2.2",
     "pg": "^8.19.0",

--- a/src/clients/database.ts
+++ b/src/clients/database.ts
@@ -1001,6 +1001,30 @@ export async function setGlobalsMessage(
     .execute();
 }
 
+export type JoustState = {
+  lastSeenJoustTime: string | null;
+  // The lastSeenJoustTime at which we last announced odds, not when odds posted
+  oddsAnnouncedFor: string | null;
+};
+
+export async function getJoustState() {
+  const row = await db
+    .selectFrom("Setting")
+    .selectAll()
+    .where("key", "=", "joust_state")
+    .executeTakeFirst();
+  if (!row) return null;
+  return row.value as JoustState;
+}
+
+export async function setJoustState(value: JoustState) {
+  await db
+    .insertInto("Setting")
+    .values({ key: "joust_state", value })
+    .onConflict((oc) => oc.column("key").doUpdateSet({ value }))
+    .execute();
+}
+
 export async function getLatestDailies() {
   const results = await sql<{
     key: string;

--- a/src/commands/kol/joust.test.ts
+++ b/src/commands/kol/joust.test.ts
@@ -1,0 +1,280 @@
+import type {
+  BettingCounter,
+  JoustOdds,
+} from "kol.js/domains/RenaissanceTimes";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const { getMrStoreItemByName, getJoustState, setJoustState } = vi.hoisted(
+  () => ({
+    getMrStoreItemByName: vi.fn(),
+    getJoustState: vi.fn(),
+    setJoustState: vi.fn(),
+  }),
+);
+
+const { alert, send, guildsFetch } = vi.hoisted(() => ({
+  alert: vi.fn(),
+  send: vi.fn(),
+  guildsFetch: vi.fn(),
+}));
+
+const { isRollover } = vi.hoisted(() => ({ isRollover: vi.fn() }));
+
+const { getBettingCounter } = vi.hoisted(() => ({
+  getBettingCounter: vi.fn(),
+}));
+
+const { config } = vi.hoisted(() => {
+  const config: { GUILD_ID: string; JOUST_CHANNEL_ID?: string } = {
+    GUILD_ID: "guild",
+    JOUST_CHANNEL_ID: "joustchan",
+  };
+  return { config };
+});
+
+vi.mock("../../clients/database.js", () => ({
+  getMrStoreItemByName,
+  getJoustState,
+  setJoustState,
+}));
+
+vi.mock("../../clients/discord.js", () => ({
+  discordClient: {
+    alert,
+    once: vi.fn(),
+    guilds: { fetch: guildsFetch },
+  },
+  createEmbed: vi.fn(() => {
+    const embed = { setTitle: vi.fn(), addFields: vi.fn() };
+    embed.setTitle.mockReturnValue(embed);
+    embed.addFields.mockReturnValue(embed);
+    return embed;
+  }),
+}));
+
+vi.mock("../../clients/kol.js", () => ({
+  kolClient: { isRollover },
+}));
+
+vi.mock("../../config.js", () => ({ config }));
+
+vi.mock("kol.js", () => ({
+  LoathingDate: {
+    getRollover: () => new Date("2026-07-25T03:30:00Z"),
+  },
+}));
+
+vi.mock("kol.js/domains/RenaissanceTimes", () => ({
+  RenaissanceTimes: class {
+    getBettingCounter = getBettingCounter;
+  },
+  KNIGHTS: ["Open Mic Knight", "Poker Knight", "Wedding Knight"],
+}));
+
+const { checkJoust, nextCheck } = await import("./joust.js");
+
+// System time for checkJoust runs: Jul 25 2026 07:43 UTC
+const NOW = new Date("2026-07-25T07:43:00Z");
+const NEWEST_JOUST = "2026-07-25T07:00:00.000Z";
+
+const OPEN_TOOLBELT = {
+  addedToStore: new Date("2026-07-20T03:30:00Z"),
+  removedFromStore: null,
+};
+
+const ODDS: JoustOdds = {
+  "Open Mic Knight": 1,
+  "Poker Knight": 57,
+  "Wedding Knight": 41,
+};
+
+function counter(overrides: Partial<BettingCounter> = {}): BettingCounter {
+  return {
+    odds: null,
+    lastWinner: "Poker Knight",
+    history: [{ time: new Date(NEWEST_JOUST), winner: "Poker Knight" }],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+
+  config.JOUST_CHANNEL_ID = "joustchan";
+  isRollover.mockReturnValue(false);
+  getMrStoreItemByName.mockResolvedValue(OPEN_TOOLBELT);
+  getBettingCounter.mockResolvedValue(counter());
+  guildsFetch.mockResolvedValue({
+    channels: {
+      cache: new Map([["joustchan", { isTextBased: () => true, send }]]),
+    },
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("checkJoust", () => {
+  test("does nothing if no announcement channel is configured", async () => {
+    config.JOUST_CHANNEL_ID = undefined;
+
+    expect(await checkJoust()).toBe("skip");
+
+    expect(getBettingCounter).not.toHaveBeenCalled();
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  test("does nothing during rollover", async () => {
+    isRollover.mockReturnValue(true);
+
+    expect(await checkJoust()).toBe("skip");
+
+    expect(getBettingCounter).not.toHaveBeenCalled();
+  });
+
+  test("does nothing while the tower is closed", async () => {
+    getMrStoreItemByName.mockResolvedValue(undefined);
+
+    expect(await checkJoust()).toBe("skip");
+
+    expect(getBettingCounter).not.toHaveBeenCalled();
+  });
+
+  test("skips quietly when the tower has faded (counter is null)", async () => {
+    getBettingCounter.mockResolvedValue(null);
+
+    expect(await checkJoust()).toBe("skip");
+
+    expect(send).not.toHaveBeenCalled();
+    expect(setJoustState).not.toHaveBeenCalled();
+  });
+
+  test("alerts and skips when the betting counter cannot be read", async () => {
+    getBettingCounter.mockRejectedValue(new Error("boom"));
+
+    expect(await checkJoust()).toBe("skip");
+
+    expect(alert).toHaveBeenCalledWith(
+      "checkJoust: could not read the betting counter",
+      undefined,
+      expect.any(Error),
+    );
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  test("first ever check syncs state without posting", async () => {
+    getBettingCounter.mockResolvedValue(counter({ odds: ODDS }));
+    getJoustState.mockResolvedValue(null);
+
+    expect(await checkJoust()).toBe("news");
+
+    expect(send).not.toHaveBeenCalled();
+    expect(setJoustState).toHaveBeenCalledWith({
+      lastSeenJoustTime: NEWEST_JOUST,
+      oddsAnnouncedFor: NEWEST_JOUST,
+    });
+  });
+
+  test("announces a recent joust winner once, syncing older ones silently", async () => {
+    getBettingCounter.mockResolvedValue(
+      counter({
+        history: [
+          { time: new Date(NEWEST_JOUST), winner: "Poker Knight" },
+          // Older than the 2h announce window: synced but not posted
+          { time: new Date("2026-07-25T01:00:00Z"), winner: "Wedding Knight" },
+        ],
+      }),
+    );
+    getJoustState.mockResolvedValue({
+      lastSeenJoustTime: "2026-07-24T23:00:00.000Z",
+      oddsAnnouncedFor: null,
+    });
+
+    expect(await checkJoust()).toBe("news");
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith("🏆 Poker Knight won the joust!");
+    expect(setJoustState).toHaveBeenCalledWith({
+      lastSeenJoustTime: NEWEST_JOUST,
+      oddsAnnouncedFor: null,
+    });
+  });
+
+  test("does not re-announce a winner it has already seen", async () => {
+    getJoustState.mockResolvedValue({
+      lastSeenJoustTime: NEWEST_JOUST,
+      oddsAnnouncedFor: null,
+    });
+
+    expect(await checkJoust()).toBe("quiet");
+
+    expect(send).not.toHaveBeenCalled();
+    expect(setJoustState).not.toHaveBeenCalled();
+  });
+
+  test("announces newly posted odds once", async () => {
+    getBettingCounter.mockResolvedValue(counter({ odds: ODDS }));
+    getJoustState.mockResolvedValue({
+      lastSeenJoustTime: NEWEST_JOUST,
+      oddsAnnouncedFor: null,
+    });
+
+    expect(await checkJoust()).toBe("news");
+
+    expect(send).toHaveBeenCalledTimes(1);
+    const message = send.mock.calls[0][0] as { content: string };
+    expect(message.content).toContain("Odds are up");
+    expect(setJoustState).toHaveBeenCalledWith({
+      lastSeenJoustTime: NEWEST_JOUST,
+      oddsAnnouncedFor: NEWEST_JOUST,
+    });
+  });
+
+  test("does not re-announce odds for the same round", async () => {
+    getBettingCounter.mockResolvedValue(counter({ odds: ODDS }));
+    getJoustState.mockResolvedValue({
+      lastSeenJoustTime: NEWEST_JOUST,
+      oddsAnnouncedFor: NEWEST_JOUST,
+    });
+
+    expect(await checkJoust()).toBe("quiet");
+
+    expect(send).not.toHaveBeenCalled();
+    expect(setJoustState).not.toHaveBeenCalled();
+  });
+});
+
+describe("nextCheck", () => {
+  const midHour = new Date("2026-07-25T07:43:00Z");
+
+  test("after news, waits until a minute past the next hour", () => {
+    expect(nextCheck(midHour, "news", 3)).toEqual({
+      delay: 18 * 60 * 1000,
+      retries: 0,
+    });
+  });
+
+  test("after a skipped check, waits until a minute past the next hour", () => {
+    expect(nextCheck(midHour, "skip", 3)).toEqual({
+      delay: 18 * 60 * 1000,
+      retries: 0,
+    });
+  });
+
+  test("with no news yet, retries in a minute", () => {
+    expect(nextCheck(midHour, "quiet", 3)).toEqual({
+      delay: 60 * 1000,
+      retries: 4,
+    });
+  });
+
+  test("gives up retrying after the cap and waits for the next hour", () => {
+    expect(nextCheck(midHour, "quiet", 15)).toEqual({
+      delay: 18 * 60 * 1000,
+      retries: 0,
+    });
+  });
+});

--- a/src/commands/kol/joust.ts
+++ b/src/commands/kol/joust.ts
@@ -1,0 +1,164 @@
+import { Events, type MessageCreateOptions } from "discord.js";
+import { LoathingDate } from "kol.js";
+import {
+  type JoustOdds,
+  KNIGHTS,
+  RenaissanceTimes,
+} from "kol.js/domains/RenaissanceTimes";
+
+import {
+  getJoustState,
+  getMrStoreItemByName,
+  setJoustState,
+} from "../../clients/database.js";
+import { createEmbed, discordClient } from "../../clients/discord.js";
+import { kolClient } from "../../clients/kol.js";
+import { config } from "../../config.js";
+import {
+  TIME_TWITCHING_TOOLBELT,
+  getTowerStatus,
+} from "../../timeTwitchingTower.js";
+
+const renaissanceTimes = new RenaissanceTimes(kolClient);
+
+// Results older than this (e.g. history seen after downtime) are recorded but
+// not announced.
+const ANNOUNCE_WINDOW = 2 * 60 * 60 * 1000;
+
+type CheckResult = "news" | "quiet" | "skip";
+
+const HOUR = 60 * 60 * 1000;
+const RETRY_DELAY = 60 * 1000;
+const MAX_RETRIES = 15;
+
+// Jousts turn over on the hour, so poll just after each hour and retry every
+// minute until the expected update lands.
+export function nextCheck(
+  now: Date,
+  result: CheckResult,
+  retries: number,
+): { delay: number; retries: number } {
+  if (result === "quiet" && retries < MAX_RETRIES) {
+    return { delay: RETRY_DELAY, retries: retries + 1 };
+  }
+
+  const nextHour = (Math.floor(now.getTime() / HOUR) + 1) * HOUR;
+  return { delay: nextHour + RETRY_DELAY - now.getTime(), retries: 0 };
+}
+
+async function post(message: string | MessageCreateOptions) {
+  if (!config.JOUST_CHANNEL_ID) return;
+  const guild = await discordClient.guilds.fetch(config.GUILD_ID);
+  const channel = guild?.channels.cache.get(config.JOUST_CHANNEL_ID);
+
+  if (!channel?.isTextBased()) {
+    await discordClient.alert(
+      "Jousting: announcement channel not found or not text-based",
+    );
+    return;
+  }
+
+  await channel.send(message);
+}
+
+function oddsMessage(odds: JoustOdds): MessageCreateOptions {
+  return {
+    content:
+      "⚔️ Odds are up at the Renaissance Times betting counter! The joust starts within the hour.",
+    embeds: [
+      createEmbed()
+        .setTitle("⚔️ Joust Odds")
+        .addFields(
+          KNIGHTS.map((knight) => ({
+            name: knight,
+            value: `${odds[knight]}%`,
+          })),
+        ),
+    ],
+  };
+}
+
+export async function checkJoust(): Promise<CheckResult> {
+  if (!config.JOUST_CHANNEL_ID) return "skip";
+  if (kolClient.isRollover()) return "skip";
+
+  const toolbelt = await getMrStoreItemByName(TIME_TWITCHING_TOOLBELT);
+  const status = getTowerStatus(toolbelt, LoathingDate.getRollover());
+  if (status !== "open" && status !== "opened") return "skip";
+
+  const now = new Date();
+
+  let counter: Awaited<ReturnType<typeof renaissanceTimes.getBettingCounter>>;
+  let state: Awaited<ReturnType<typeof getJoustState>>;
+  try {
+    [counter, state] = await Promise.all([
+      renaissanceTimes.getBettingCounter(now),
+      getJoustState(),
+    ]);
+  } catch (error) {
+    await discordClient.alert(
+      "checkJoust: could not read the betting counter",
+      undefined,
+      error,
+    );
+    return "skip";
+  }
+  if (counter === null) return "skip";
+
+  const newestJoust = counter.history[0]?.time.toISOString() ?? null;
+
+  if (!state) {
+    await setJoustState({
+      lastSeenJoustTime: newestJoust,
+      oddsAnnouncedFor: counter.odds ? newestJoust : null,
+    });
+    return "news";
+  }
+
+  let news = false;
+
+  const lastSeen = state.lastSeenJoustTime
+    ? new Date(state.lastSeenJoustTime).getTime()
+    : 0;
+  const newRounds = counter.history
+    .filter((round) => round.time.getTime() > lastSeen)
+    .toReversed();
+  for (const round of newRounds) {
+    news = true;
+    if (now.getTime() - round.time.getTime() > ANNOUNCE_WINDOW) continue;
+    await post(`🏆 ${round.winner} won the joust!`);
+  }
+
+  let oddsAnnouncedFor = state.oddsAnnouncedFor;
+  if (counter.odds && oddsAnnouncedFor !== newestJoust) {
+    await post(oddsMessage(counter.odds));
+    oddsAnnouncedFor = newestJoust;
+    news = true;
+  }
+
+  if (news) {
+    await setJoustState({
+      lastSeenJoustTime: newestJoust ?? state.lastSeenJoustTime,
+      oddsAnnouncedFor,
+    });
+  }
+
+  return news ? "news" : "quiet";
+}
+
+async function loop(retries: number) {
+  let result: CheckResult = "skip";
+  try {
+    result = await checkJoust();
+  } catch (error) {
+    await discordClient.alert("checkJoust failed", undefined, error);
+  }
+
+  const next = nextCheck(new Date(), result, retries);
+  setTimeout(() => void loop(next.retries), next.delay);
+}
+
+export function init() {
+  if (!config.JOUST_CHANNEL_ID) return;
+  discordClient.once(Events.ClientReady, () => void loop(0));
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -87,6 +87,12 @@ export const schema = {
 
   // Newsletter
   NEWSLETTER_CHANNEL_ID: SNOWFLAKE_PATTERN,
+
+  // Jousting (Time-Twitching Tower)
+  JOUST_CHANNEL_ID: {
+    type: SNOWFLAKE_PATTERN,
+    optional: true,
+  },
 };
 
 export type Env = EnvType<typeof schema>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -263,6 +263,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@date-fns/tz@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "@date-fns/tz@npm:1.5.0"
+  checksum: 10c0/4ef25eedd55924938fa81b23b949a3425201597e2007f5323db54d50fc19283eca5e2a7963c3d82c99b3adf273e9ea9bc7adfd1c9076e15badd99c593a984ffa
+  languageName: node
+  linkType: hard
+
 "@dimforge/rapier3d-compat@npm:~0.12.0":
   version: 0.12.0
   resolution: "@dimforge/rapier3d-compat@npm:0.12.0"
@@ -4802,10 +4809,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"kol.js@npm:^0.11.0":
-  version: 0.11.0
-  resolution: "kol.js@npm:0.11.0"
+"kol.js@npm:^0.13.0":
+  version: 0.13.0
+  resolution: "kol.js@npm:0.13.0"
   dependencies:
+    "@date-fns/tz": "npm:^1.5.0"
     async-mutex: "npm:^0.5.0"
     chevrotain: "npm:^12.0.0"
     css-select: "npm:^6.0.0"
@@ -4825,7 +4833,7 @@ __metadata:
     zod: "npm:^4.4.3"
   peerDependencies:
     data-of-loathing: ">=4.3.0"
-  checksum: 10c0/003d5831ceb788187fdddeee78ecc044385568baa678cd5b9d6d1f8562f4912598754ff9993b300d49cd0f8601f5a3fa9ed5158db6e5cfee13a0c37463f40f91
+  checksum: 10c0/b631871a20e1edd7b3c9d921123872b18d3982d6ecb88bdf26813cdd23f85a7e95d959814a50d385f4a62a27230457a2f813be1bd6ddc3a55f14c49244c19052
   languageName: node
   linkType: hard
 
@@ -5495,7 +5503,7 @@ __metadata:
     jiti: "npm:^2.6.1"
     js-sha256: "npm:^0.11.1"
     jsonwebtoken: "npm:^9.0.3"
-    kol.js: "npm:^0.11.0"
+    kol.js: "npm:^0.13.0"
     kysely: "npm:^0.28.11"
     kysely-ctl: "npm:^0.20.0"
     lightstreamer-client-node: "npm:^9.2.2"


### PR DESCRIPTION
Adds a task that watches the Renaissance Times betting counter in the Time-Twitching Tower and posts to Discord when odds go up and when a joust winner is revealed.

## Behaviour
- Runs only while the tower is open, gated on the `time-twitching toolbelt` being in Mr. Store (`getTowerStatus`) — a cheap DB check, no KoL requests while the tower is closed. Also skips during rollover.
- Reads the betting counter via the new `RenaissanceTimes` domain in kol.js (`getBettingCounter`), which navigates in and backs out of the choice cleanly. A closed tower (faded into the mists) is a quiet skip; an unreadable page alerts.
- Posts a `🏆 <knight> won the joust!` message when a new result appears, and an odds embed when odds are first posted for a cycle.
- Dedupe state lives in the `Setting` table (`joust_state`), so restarts don't double-post; results older than the 2h window (e.g. history seen after downtime) are recorded silently rather than announced.
- Polling is hour-aligned to the joust cycle: check just after each hour, retry every minute until the expected update lands.

## Config
- New optional `JOUST_CHANNEL_ID`. The feature is completely inert if it isn't set.

## Dependencies
- Requires **kol.js 0.13.0** (adds the `RenaissanceTimes` domain).

## Tests
- `src/commands/kol/joust.test.ts` mocks the domain and covers the gates (channel/rollover/closed), faded-vs-error handling, first-run silent sync, the announce window, winner/odds dedup, and the scheduler.